### PR TITLE
Display editable template options to convert to for each page

### DIFF
--- a/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/PageStructureRewriteRule.java
+++ b/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/PageStructureRewriteRule.java
@@ -22,4 +22,10 @@ package com.adobe.aem.modernize.structure;
 public interface PageStructureRewriteRule extends StructureRewriteRule{
 
     String getStaticTemplate();
+
+    /**
+     * Gets the editable template for this structure rewrite rule
+     * @return
+     */
+    String getEditableTemplate();
 }

--- a/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/StructureRewriteRuleService.java
+++ b/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/StructureRewriteRuleService.java
@@ -19,13 +19,9 @@
 
 package com.adobe.aem.modernize.structure;
 
-import java.util.Set;
-
-import org.apache.sling.api.resource.ResourceResolver;
-
-import com.adobe.aem.modernize.RewriteException;
 import com.adobe.aem.modernize.RewriteRuleService;
-import com.adobe.aem.modernize.component.ComponentRewriteRule;
+
+import java.util.Set;
 
 /**
  * Provides a mechanism for listing all of the configured rules either via Nodes or custom implementations.
@@ -37,4 +33,11 @@ public interface StructureRewriteRuleService extends RewriteRuleService<Structur
      * @return
      */
     Set<String> getTemplates();
+
+    /**
+     * List all the editable templates for the given static template
+     * @param staticTemplate
+     * @return
+     */
+    Set<String> getEditableTemplates(String staticTemplate);
 }

--- a/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/datasources/PageDataSource.java
+++ b/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/datasources/PageDataSource.java
@@ -20,11 +20,7 @@
 package com.adobe.aem.modernize.structure.datasources;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
@@ -37,7 +33,6 @@ import com.adobe.aem.modernize.impl.RewriteUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
-import org.apache.jackrabbit.util.ISO9075;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
@@ -124,14 +119,21 @@ public final class PageDataSource extends SlingSafeMethodsServlet {
             if (pageContent.hasProperty(NameConstants.PN_TITLE)) {
                 title = pageContent.getProperty(NameConstants.PN_TITLE).getString();
             }
-            Map<String, Object> map = new HashMap<>();
-            map.put("title", title);
-            map.put("pagePath", pagePath);
-            map.put("templateType", pageContent.getProperty(NameConstants.NN_TEMPLATE).getString());
-            map.put("href", href);
-            map.put("crxHref", crxHref);
-            resources.add(new ValueMapResource(request.getResourceResolver(), request.getResource() + "/page" + index, itemResourceType, new ValueMapDecorator(map)));
-            index++;
+
+            String staticTemplate = pageContent.getProperty(NameConstants.NN_TEMPLATE).getString();
+            Set<String> editableTemplates = structureRewriteRuleService.getEditableTemplates(staticTemplate);
+
+            for(String editableTmpl : editableTemplates) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("title", title);
+                map.put("pagePath", pagePath);
+                map.put("templateType", staticTemplate);
+                map.put("editableTemplate", editableTmpl);
+                map.put("href", href);
+                map.put("crxHref", crxHref);
+                resources.add(new ValueMapResource(request.getResourceResolver(), request.getResource() + "/page" + index, itemResourceType, new ValueMapDecorator(map)));
+                index++;
+            }
         }
         return resources;
     }

--- a/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/impl/StructureRewriteRuleServiceImpl.java
+++ b/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/impl/StructureRewriteRuleServiceImpl.java
@@ -19,12 +19,8 @@
 
 package com.adobe.aem.modernize.structure.impl;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
@@ -33,7 +29,6 @@ import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.resource.ResourceResolver;
 
-import com.adobe.aem.modernize.RewriteException;
 import com.adobe.aem.modernize.structure.PageStructureRewriteRule;
 import com.adobe.aem.modernize.structure.StructureRewriteRule;
 import com.adobe.aem.modernize.structure.StructureRewriteRuleService;
@@ -99,6 +94,14 @@ public class StructureRewriteRuleServiceImpl implements StructureRewriteRuleServ
             templates.add(r.getStaticTemplate());
         }
         return templates;
+    }
+
+    @Override
+    public Set<String> getEditableTemplates(String staticTemplate) {
+        return pageRules.stream()
+                .filter(rule -> rule.getStaticTemplate().equals(staticTemplate))
+                .map(PageStructureRewriteRule::getEditableTemplate)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/impl/rules/PageRewriteRule.java
+++ b/bundles/aem-modernize-tools/src/main/java/com/adobe/aem/modernize/structure/impl/rules/PageRewriteRule.java
@@ -303,6 +303,11 @@ public class PageRewriteRule implements PageStructureRewriteRule {
     }
 
     @Override
+    public String getEditableTemplate() {
+        return editableTemplate;
+    }
+
+    @Override
     public int getRanking() {
         return this.ranking;
     }

--- a/bundles/aem-modernize-tools/src/test/java/com/adobe/aem/modernize/structure/impl/StructureRewriteRuleServiceImplTest.java
+++ b/bundles/aem-modernize-tools/src/test/java/com/adobe/aem/modernize/structure/impl/StructureRewriteRuleServiceImplTest.java
@@ -50,8 +50,8 @@ public class StructureRewriteRuleServiceImplTest {
 
     private static final String STATIC_HOME_TEMPLATE = "/apps/geometrixx/templates/homepage";
     private static final String STATIC_PRODUCT_TEMPLATE = "/apps/geometrixx/templates/productpage";
-    private static final String EDITABLE_TEMPLATE = "/conf/geodemo/settings/wcm/templates/geometrixx-demo-home-page";
-    private static final String SLING_RESOURCE_TYPE = "geodemo/components/structure/page";
+    private static final String EDITABLE_HOME_TEMPLATE = "/conf/geodemo/settings/wcm/templates/geometrixx-demo-home-page";
+    private static final String EDITABLE_PRODUCT_TEMPLATE = "/conf/geodemo/settings/wcm/templates/geometrixx-demo-product-page";    private static final String SLING_RESOURCE_TYPE = "geodemo/components/structure/page";
 
     private static final String LAYOUT_VALUE = "2;cq-colctrl-lt0";
     private static final String[] COLUMN_WIDTHS = {"6", "6"};
@@ -82,7 +82,7 @@ public class StructureRewriteRuleServiceImplTest {
         StructureRewriteRule rule = new PageRewriteRule();
         Dictionary<String, Object> props = new Hashtable<>();
         props.put("static.template", STATIC_HOME_TEMPLATE);
-        props.put("editable.template", EDITABLE_TEMPLATE);
+        props.put("editable.template", EDITABLE_HOME_TEMPLATE);
         props.put("sling.resourceType", SLING_RESOURCE_TYPE);
         MockOsgi.activate(rule, bundleContext, props);
         context.registerService(PageStructureRewriteRule.class, (PageStructureRewriteRule) rule);
@@ -92,7 +92,16 @@ public class StructureRewriteRuleServiceImplTest {
         props = new Hashtable<>();
         props.put("static.template", STATIC_PRODUCT_TEMPLATE);
         props.put("sling.resourceType", SLING_RESOURCE_TYPE);
-        props.put("editable.template", "/conf/geodemo/settings/wcm/templates/geometrixx-demo-product-page");
+        props.put("editable.template", EDITABLE_PRODUCT_TEMPLATE);
+        MockOsgi.activate(rule, bundleContext, props);
+        context.registerService(PageStructureRewriteRule.class, (PageStructureRewriteRule) rule);
+        rules.add(rule);
+
+        rule = new PageRewriteRule();
+        props = new Hashtable<>();
+        props.put("static.template", STATIC_PRODUCT_TEMPLATE);
+        props.put("sling.resourceType", SLING_RESOURCE_TYPE);
+        props.put("editable.template", EDITABLE_HOME_TEMPLATE);
         MockOsgi.activate(rule, bundleContext, props);
         context.registerService(PageStructureRewriteRule.class, (PageStructureRewriteRule) rule);
         rules.add(rule);
@@ -130,9 +139,11 @@ public class StructureRewriteRuleServiceImplTest {
         List<StructureRewriteRule> rules = structureRewriteRuleService.getRules(null);
         assertNotNull(rules);
         assertFalse(rules.isEmpty());
-        assertEquals(4, rules.size());
+        assertEquals(5, rules.size());
         Iterator<StructureRewriteRule> it = rules.iterator();
         StructureRewriteRule rule = it.next();
+        assertTrue(rule instanceof PageStructureRewriteRule);
+        rule = it.next();
         assertTrue(rule instanceof PageStructureRewriteRule);
         rule = it.next();
         assertTrue(rule instanceof PageStructureRewriteRule);
@@ -140,6 +151,20 @@ public class StructureRewriteRuleServiceImplTest {
         assertTrue(rule instanceof ParsysRewriteRule);
         rule = it.next();
         assertTrue(rule instanceof ColumnControlRewriteRule);
+    }
 
+    @Test
+    public void testGetEditableTemplates() {
+        Set<String> templates = structureRewriteRuleService.getEditableTemplates(STATIC_HOME_TEMPLATE);
+        assertEquals(1, templates.size());
+        assertTrue(templates.contains(EDITABLE_HOME_TEMPLATE));
+    }
+
+    @Test
+    public void testGetEditableTemplatesWithMultiple() {
+        Set<String> templates = structureRewriteRuleService.getEditableTemplates(STATIC_PRODUCT_TEMPLATE);
+        assertEquals(2, templates.size());
+        assertTrue(templates.contains(EDITABLE_PRODUCT_TEMPLATE));
+        assertTrue(templates.contains(EDITABLE_HOME_TEMPLATE));
     }
 }

--- a/content/jcr_root/libs/cq/modernize/templatestructure/clientlib/js/structure.js
+++ b/content/jcr_root/libs/cq/modernize/templatestructure/clientlib/js/structure.js
@@ -81,6 +81,11 @@ $(document).ready(function () {
             var selection = event && event.detail && event.detail.selection ? event.detail.selection : [];
             var count = selection.length;
 
+            // un-hide all rows
+            for (var i = 0; i < pageRows.length; i++) {
+                pageRows[i].set('hidden', false, true);
+            }
+
             // Deselect already converted structures
             for (var i = 0; i < selection.length; i++) {
                 var row = selection[i];
@@ -89,6 +94,14 @@ $(document).ready(function () {
                     row.set('selected', false, true);
                     count--;
                 }
+
+                // hide other template options for selected page
+                var selectedPage = row.dataset['foundationCollectionItemId'];
+                for (var j = 0, length = pageRows.length; j < length; j++) {
+                    if(!pageRows[j].selected && pageRows[j].dataset['foundationCollectionItemId'] === selectedPage) {
+                        pageRows[j].set('hidden', true, true);
+                    }
+                }
             }
 
             adjustConvertButton(count);
@@ -96,24 +109,29 @@ $(document).ready(function () {
 
         convertPagesButton.on("click", function () {
             // get paths from table
-            var paths = [];
+            var pages = [];
 
             var selectedStructureRows = pageTable.selectedItems;
             for (var i = 0, length = selectedStructureRows.length; i < length; i++) {
-                var value = selectedStructureRows[i].dataset["foundationCollectionItemId"];
+                var path = selectedStructureRows[i].dataset["foundationCollectionItemId"];
+                var tmpl = selectedStructureRows[i].dataset["modernizeEditabletmpl"];
 
-                if (value) {
-                    paths.push(value);
+                if (path) {
+                    pages.push({
+                        path: path,
+                        template: tmpl
+                    });
                 }
             }
 
             var url = REMOTE_STRUCTURE_CONVERSION_SERVICE_PATH + "/content/convert.json";
-            var data = {
-                paths : paths
-            };
 
             // show overlay and wait
             ui.wait();
+
+            var data = JSON.stringify({
+                pages: pages
+            });
 
             $.post(url, data, function (data) {
                 convertPagesButton.hidden = true;

--- a/content/jcr_root/libs/cq/modernize/templatestructure/content/console/.content.xml
+++ b/content/jcr_root/libs/cq/modernize/templatestructure/content/console/.content.xml
@@ -72,7 +72,7 @@
                             </secondary>
                         </actionbar>
                         <pages
-                            granite:class="js-aem-StructureConverter-pages"
+                            granite:class="aem-StructureConverter-pages js-aem-StructureConverter-pages"
                             granite:rel="aem-modernize-structure-pages"
                             jcr:primaryType="nt:unstructured"
                             sling:resourceType="granite/ui/components/coral/foundation/table"
@@ -92,6 +92,11 @@
                                 <template
                                     jcr:primaryType="nt:unstructured"
                                     jcr:title="Template"
+                                    alignment="center"
+                                    sortable="{Boolean}true"/>
+                                <editableTemplate
+                                    jcr:primaryType="nt:unstructured"
+                                    jcr:title="Editable Template"
                                     alignment="center"
                                     sortable="{Boolean}true"/>
                                 <links

--- a/content/jcr_root/libs/cq/modernize/templatestructure/content/item/item.html
+++ b/content/jcr_root/libs/cq/modernize/templatestructure/content/item/item.html
@@ -16,12 +16,14 @@
     class="${!converted ? 'foundation-collection-item' : ''}"
     data-foundation-collection-item-id="${properties.pagePath @ uri}"
     data-sly-attribute.hidden="${converted ? converted : ''}"
-    data-sly-attribute.data-modernize-component-converted="${converted ? converted : ''}">
+    data-sly-attribute.data-modernize-component-converted="${converted ? converted : ''}"
+    data-sly-attribute.data-modernize-editabletmpl="${properties.editableTemplate}">
     <td is="coral-table-cell">
         <coral-checkbox disabled="${converted}" coral-table-rowselect></coral-checkbox>
     </td>
     <td is="coral-table-cell">${properties.title} (${properties.pagePath @ uri})</td>
     <td is="coral-table-cell">${properties.templateType}</td>
+    <td is="coral-table-cell">${properties.editableTemplate}</td>
     <td is="coral-table-cell">
         <a href="${properties.href @ uri}" target="_blank" class="coral-Link">${'show' @ i18n}</a> / <a href="${properties.crxHref @ uri}" x-cq-linkchecker="skip" target="_blank" class="coral-Link">crxde</a>
     </td>


### PR DESCRIPTION
This is an implementation of the feature request lodged here: https://github.com/adobe/aem-modernize-tools/issues/16

With the current tool, when multiple editable template configurations are provided for one classic template, only one is chosen arbitrarily. Instead, the tool can now list the editable template options available and let's the user choose which one should be used. 

Example config 1:
```
staticTemplate=/apps/helloworld/templates/base-page
editableTemplate=/conf/we-retail/settings/wcm/templates/experience-page
```
Example config 2:
```
staticTemplate=/apps/helloworld/templates/base-page
editableTemplate=/conf/we-retail/settings/wcm/templates/hero-page
```
Available Classic pages and corresponding Editable templates:
<img width="1440" alt="editable-template-options" src="https://user-images.githubusercontent.com/7494904/67255671-f9a08e00-f4ce-11e9-95ce-9458d2dc1288.png">
Selecting a row hides other options:
<img width="1440" alt="editable-template-options2" src="https://user-images.githubusercontent.com/7494904/67255705-22288800-f4cf-11e9-85ae-d5f877ea7053.png">


