### PR TITLE
Fix build by not overriding bndlib and pinning maven-bundle-plugin

### DIFF
--- a/bundles/aem-modernize-tools/pom.xml
+++ b/bundles/aem-modernize-tools/pom.xml
@@ -100,14 +100,8 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>4.1.0</version>
                 <extensions>true</extensions>
-                <dependencies>
-                    <dependency>
-                        <groupId>biz.aQute.bnd</groupId>
-                        <artifactId>bndlib</artifactId>
-                        <version>2.4.0</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <!-- Configure extra execution of 'manifest' in process-classes phase to make sure SCR metadata is generated before unit test runs -->
                     <execution>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -280,14 +280,8 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
+                    <version>4.1.0</version>
                     <extensions>true</extensions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>biz.aQute.bnd</groupId>
-                            <artifactId>bndlib</artifactId>
-                            <version>2.4.0</version>
-                        </dependency>
-                    </dependencies>
                     <executions>
                         <!-- Configure extra execution of 'manifest' in process-classes phase to make sure SCR metadata is generated before unit test runs -->
                         <execution>


### PR DESCRIPTION
I noticed building the project fails on my machine (Windows 10 and also inside an Ubuntu VM):
```bash
[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:4.2.1:bundle (default-bundle) on project aem-modernize-tools: Execution default-bundle of goal org.apache.felix:maven-bundle-plugin:4.2.1:bundle failed: An API incompatibility was encountered while executing org.apache.felix:maven-bundle-plugin:4.2.1:bundle: java.lang.NoSuchMethodError: aQute.bnd.osgi.Builder.setClasspath(Ljava/util/Collection;)V
[ERROR] -----------------------------------------------------
[ERROR] realm =    extension>org.apache.felix:maven-bundle-plugin:4.2.1
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/user/.m2/repository/org/apache/felix/maven-bundle-plugin/4.2.1/maven-bundle-plugin-4.2.1.jar
[ERROR] urls[1] = file:/home/user/.m2/repository/biz/aQute/bnd/bndlib/2.4.0/bndlib-2.4.0.jar
[ERROR] urls[2] = file:/home/user/.m2/repository/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar
[ERROR] urls[3] = file:/home/user/.m2/repository/biz/aQute/bnd/biz.aQute.bndlib/4.2.0/biz.aQute.bndlib-4.2.0.jar
[ERROR] urls[4] = file:/home/user/.m2/repository/org/apache/felix/org.apache.felix.bundlerepository/1.6.6/org.apache.felix.bundlerepository-1.6.6.jar
[ERROR] urls[5] = file:/home/user/.m2/repository/org/easymock/easymock/2.4/easymock-2.4.jar
[ERROR] urls[6] = file:/home/user/.m2/repository/org/apache/felix/org.apache.felix.utils/1.6.0/org.apache.felix.utils-1.6.0.jar
[ERROR] urls[7] = file:/home/user/.m2/repository/org/osgi/org.osgi.compendium/4.2.0/org.osgi.compendium-4.2.0.jar
[ERROR] urls[8] = file:/home/user/.m2/repository/org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar
[ERROR] urls[9] = file:/home/user/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar
[ERROR] urls[10] = file:/home/user/.m2/repository/org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar
[ERROR] urls[11] = file:/home/user/.m2/repository/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar
[ERROR] urls[12] = file:/home/user/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar
[ERROR] urls[13] = file:/home/user/.m2/repository/com/google/inject/guice/4.0/guice-4.0-no_aop.jar
[ERROR] urls[14] = file:/home/user/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar
[ERROR] urls[15] = file:/home/user/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar
[ERROR] urls[16] = file:/home/user/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar
[ERROR] urls[17] = file:/home/user/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[18] = file:/home/user/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[19] = file:/home/user/.m2/repository/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar
[ERROR] urls[20] = file:/home/user/.m2/repository/org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.jar
[ERROR] urls[21] = file:/home/user/.m2/repository/org/apache/maven/maven-archiver/2.6/maven-archiver-2.6.jar
[ERROR] urls[22] = file:/home/user/.m2/repository/org/apache/maven/shared/maven-shared-utils/0.7/maven-shared-utils-0.7.jar
[ERROR] urls[23] = file:/home/user/.m2/repository/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar
[ERROR] urls[24] = file:/home/user/.m2/repository/org/codehaus/plexus/plexus-archiver/2.8.1/plexus-archiver-2.8.1.jar
[ERROR] urls[25] = file:/home/user/.m2/repository/org/codehaus/plexus/plexus-io/2.3.2/plexus-io-2.3.2.jar
[ERROR] urls[26] = file:/home/user/.m2/repository/org/apache/commons/commons-compress/1.9/commons-compress-1.9.jar
[ERROR] urls[27] = file:/home/user/.m2/repository/org/apache/maven/shared/maven-dependency-tree/2.1/maven-dependency-tree-2.1.jar
[ERROR] urls[28] = file:/home/user/.m2/repository/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar
[ERROR] urls[29] = file:/home/user/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.10/plexus-utils-3.0.10.jar
[ERROR] urls[30] = file:/home/user/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
[ERROR] urls[31] = file:/home/user/.m2/repository/org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.jar
[ERROR] urls[32] = file:/home/user/.m2/repository/org/apache/maven/doxia/doxia-site-renderer/1.0/doxia-site-renderer-1.0.jar
[ERROR] urls[33] = file:/home/user/.m2/repository/org/apache/maven/doxia/doxia-core/1.0/doxia-core-1.0.jar
[ERROR] urls[34] = file:/home/user/.m2/repository/org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.jar
[ERROR] urls[35] = file:/home/user/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar
[ERROR] urls[36] = file:/home/user/.m2/repository/org/codehaus/plexus/plexus-velocity/1.1.7/plexus-velocity-1.1.7.jar
[ERROR] urls[37] = file:/home/user/.m2/repository/org/apache/velocity/velocity/1.5/velocity-1.5.jar
[ERROR] urls[38] = file:/home/user/.m2/repository/commons-lang/commons-lang/2.1/commons-lang-2.1.jar
[ERROR] urls[39] = file:/home/user/.m2/repository/oro/oro/2.0.8/oro-2.0.8.jar
[ERROR] urls[40] = file:/home/user/.m2/repository/org/apache/maven/doxia/doxia-decoration-model/1.0/doxia-decoration-model-1.0.jar
[ERROR] urls[41] = file:/home/user/.m2/repository/commons-collections/commons-collections/3.2/commons-collections-3.2.jar
[ERROR] urls[42] = file:/home/user/.m2/repository/org/apache/maven/doxia/doxia-module-apt/1.0/doxia-module-apt-1.0.jar
[ERROR] urls[43] = file:/home/user/.m2/repository/org/apache/maven/doxia/doxia-module-fml/1.0/doxia-module-fml-1.0.jar
[ERROR] urls[44] = file:/home/user/.m2/repository/org/apache/maven/doxia/doxia-module-xdoc/1.0/doxia-module-xdoc-1.0.jar
[ERROR] urls[45] = file:/home/user/.m2/repository/org/apache/maven/doxia/doxia-module-xhtml/1.0/doxia-module-xhtml-1.0.jar
[ERROR] urls[46] = file:/home/user/.m2/repository/org/jdom/jdom/1.1/jdom-1.1.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
```

That probably happens due to `bndlib` being overwritten for `maven-bundle-plugin`.