### PR TITLE
Fix for Issue #29

### DIFF
--- a/bundles/aem-modernize-tools/pom.xml
+++ b/bundles/aem-modernize-tools/pom.xml
@@ -101,13 +101,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <dependencies>
-                    <dependency>
-                        <groupId>biz.aQute.bnd</groupId>
-                        <artifactId>bndlib</artifactId>
-                        <version>2.4.0</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <!-- Configure extra execution of 'manifest' in process-classes phase to make sure SCR metadata is generated before unit test runs -->
                     <execution>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -281,13 +281,7 @@
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <extensions>true</extensions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>biz.aQute.bnd</groupId>
-                            <artifactId>bndlib</artifactId>
-                            <version>2.4.0</version>
-                        </dependency>
-                    </dependencies>
+                   
                     <executions>
                         <!-- Configure extra execution of 'manifest' in process-classes phase to make sure SCR metadata is generated before unit test runs -->
                         <execution>
@@ -570,6 +564,13 @@
                 <version>2.4.0</version>
                 <scope>provided</scope>
             </dependency>
+            <!-- https://mvnrepository.com/artifact/biz.aQute.bnd/biz.aQute.bndlib -->
+<!--            <dependency>-->
+<!--                <groupId>biz.aQute.bnd</groupId>-->
+<!--                <artifactId>biz.aQute.bndlib</artifactId>-->
+<!--                <version>5.1.1</version>-->
+<!--                <scope>provided</scope>-->
+<!--            </dependency>-->
 
 
             <!-- Servlet API -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -564,14 +564,6 @@
                 <version>2.4.0</version>
                 <scope>provided</scope>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/biz.aQute.bnd/biz.aQute.bndlib -->
-<!--            <dependency>-->
-<!--                <groupId>biz.aQute.bnd</groupId>-->
-<!--                <artifactId>biz.aQute.bndlib</artifactId>-->
-<!--                <version>5.1.1</version>-->
-<!--                <scope>provided</scope>-->
-<!--            </dependency>-->
-
 
             <!-- Servlet API -->
             <dependency>


### PR DESCRIPTION
#29 

this PR removes the hardcoded version dependency for biz.aQute.bnd 2.4.0. The project successfully builts again.

Tested with:

- Windows 10 / latest MacOS
- Java 8 v201
- Maven 3.6.0