### PR TITLE
Copy or Restore Pages - not both

### DIFF
--- a/core/src/main/java/com/adobe/aem/modernize/impl/RewriteUtils.java
+++ b/core/src/main/java/com/adobe/aem/modernize/impl/RewriteUtils.java
@@ -77,19 +77,6 @@ public class RewriteUtils {
     }
   }
 
-  /**
-   * Given a source path, and destination relative root, determine where a new path would be, if depth in repository were kept constant.
-   *
-   * @param source     source path
-   * @param targetRoot target path
-   * @return the new path to the resource
-   */
-  public static String calcNewPath(String source, String targetRoot) {
-    int depth = PathUtils.getDepth(targetRoot);
-    int relDepth = PathUtils.getDepth(source) - depth;
-    String relPath = PathUtils.getAncestorPath(source, relDepth);
-    return source.replaceFirst(relPath, targetRoot);
-  }
 
   public static Page restore(PageManager pm, Page page) throws WCMException {
     String version = page.getProperties().get(PN_PRE_MODERNIZE_VERSION, String.class);
@@ -112,8 +99,9 @@ public class RewriteUtils {
     }
   }
 
-  public static Page copyPage(PageManager pm, Page source, String targetRoot) throws WCMException, RewriteException {
-    String target = RewriteUtils.calcNewPath(source.getPath(), targetRoot);
+  public static Page copyPage(PageManager pm, Page source, String sourceRoot, String targetRoot) throws WCMException, RewriteException {
+
+    String target = source.getPath().replace(sourceRoot, targetRoot);
     Page page = pm.getPage(target);
     if (page != null) {
       throw new RewriteException(String.format("Target page already exists for requested copy: {}", target));

--- a/core/src/main/java/com/adobe/aem/modernize/job/AbstractConversionJobExecutor.java
+++ b/core/src/main/java/com/adobe/aem/modernize/job/AbstractConversionJobExecutor.java
@@ -197,12 +197,21 @@ public abstract class AbstractConversionJobExecutor implements JobExecutor {
   }
 
   @Nullable
-  protected String getTargetPath(ConversionJobBucket bucket) {
+  protected String getSourceRoot(ConversionJobBucket bucket) {
     ValueMap vm = getTrackingInfo(bucket);
     if (vm == null) {
       return null;
     }
-    return vm.get(PN_TARGET_PATH, String.class);
+    return vm.get(PN_SOURCE_ROOT, String.class);
+  }
+
+  @Nullable
+  protected String getTargetRoot(ConversionJobBucket bucket) {
+    ValueMap vm = getTrackingInfo(bucket);
+    if (vm == null) {
+      return null;
+    }
+    return vm.get(PN_TARGET_ROOT, String.class);
   }
 
   @NotNull

--- a/core/src/main/java/com/adobe/aem/modernize/job/AbstractConversionJobExecutor.java
+++ b/core/src/main/java/com/adobe/aem/modernize/job/AbstractConversionJobExecutor.java
@@ -175,12 +175,16 @@ public abstract class AbstractConversionJobExecutor implements JobExecutor {
     return Boolean.TRUE.equals(vm.get(PN_OVERWRITE, Boolean.class));
   }
 
-  protected boolean isReprocess(ConversionJobBucket bucket) {
+  protected PageHandling getPageHandling(ConversionJobBucket bucket) {
     ValueMap vm = getTrackingInfo(bucket);
     if (vm == null) {
-      return false;
+      return PageHandling.NONE;
     }
-    return Boolean.TRUE.equals(vm.get(PN_REPROCESS, Boolean.class));
+    try {
+      return PageHandling.valueOf(vm.get(PN_PAGE_HANDLING, PageHandling.NONE.name()));
+    } catch (IllegalArgumentException e) {
+      return PageHandling.NONE;
+    }
   }
 
   @Nullable

--- a/core/src/main/java/com/adobe/aem/modernize/job/FullConversionJobExecutor.java
+++ b/core/src/main/java/com/adobe/aem/modernize/job/FullConversionJobExecutor.java
@@ -9,9 +9,9 @@ package com.adobe.aem.modernize.job;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
@@ -58,9 +57,8 @@ import com.day.cq.wcm.api.designer.Style;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import static com.adobe.aem.modernize.policy.PolicyImportRuleService.*;
-
 import static com.adobe.aem.modernize.model.ConversionJob.PageHandling.*;
+import static com.adobe.aem.modernize.policy.PolicyImportRuleService.*;
 
 @Component(
     service = { JobExecutor.class },
@@ -94,7 +92,8 @@ public class FullConversionJobExecutor extends AbstractConversionJobExecutor {
 
     final ConversionJob.PageHandling pageHandling = getPageHandling(bucket);
     final boolean overwritePolicies = isOverwrite(bucket);
-    String targetPath = getTargetPath(bucket);
+    String sourceRoot = getSourceRoot(bucket);
+    String targetRoot = getTargetRoot(bucket);
 
     Resource resource = bucket.getResource();
     ResourceResolver rr = resource.getResourceResolver();
@@ -117,7 +116,7 @@ public class FullConversionJobExecutor extends AbstractConversionJobExecutor {
         continue;
       }
 
-      if (pageHandling == COPY && StringUtils.isBlank(targetPath)) {
+      if (pageHandling == COPY && (StringUtils.isBlank(sourceRoot) || StringUtils.isBlank(targetRoot))) {
         bucket.getFailed().add(path);
         continue;
       }
@@ -135,7 +134,7 @@ public class FullConversionJobExecutor extends AbstractConversionJobExecutor {
         RewriteUtils.createVersion(pm, page);
 
         if (pageHandling == COPY) {
-          page = RewriteUtils.copyPage(pm, page, targetPath);
+          page = RewriteUtils.copyPage(pm, page, sourceRoot, targetRoot);
         }
 
         if (!templateRules.isEmpty()) {
@@ -170,18 +169,6 @@ public class FullConversionJobExecutor extends AbstractConversionJobExecutor {
   @Override
   protected ResourceResolverFactory getResourceResolverFactory() {
     return resourceResolverFactory;
-  }
-
-  private void fixChildrenOrder(Page page) throws RewriteException {
-    Iterator<Page> children = page.listChildren();
-    if (children.hasNext()) {
-      Node node = page.adaptTo(Node.class);
-      try {
-        node.orderBefore(NameConstants.NN_CONTENT, children.next().getName());
-      } catch (RepositoryException e) {
-        throw new RewriteException("Unable to re-order page's JCR Content Node.", e);
-      }
-    }
   }
 
   // Import any styles used by this page - set the new policy reference for later use.
@@ -256,6 +243,18 @@ public class FullConversionJobExecutor extends AbstractConversionJobExecutor {
         }
       }
     }.accept(page.getContentResource());
+  }
+
+  private void fixChildrenOrder(Page page) throws RewriteException {
+    Iterator<Page> children = page.listChildren();
+    if (children.hasNext()) {
+      Node node = page.adaptTo(Node.class);
+      try {
+        node.orderBefore(NameConstants.NN_CONTENT, children.next().getName());
+      } catch (RepositoryException e) {
+        throw new RewriteException("Unable to re-order page's JCR Content Node.", e);
+      }
+    }
   }
 
 }

--- a/core/src/main/java/com/adobe/aem/modernize/job/datasource/ConversionJobDataSource.java
+++ b/core/src/main/java/com/adobe/aem/modernize/job/datasource/ConversionJobDataSource.java
@@ -205,7 +205,7 @@ public class ConversionJobDataSource extends SlingSafeMethodsServlet {
       Calendar finished =  cj.getFinished();
       if (finished != null) {
         vm.put("finishedMs", finished.getTimeInMillis());
-        vm.put("finished", finished.toInstant());
+        vm.put("finished", finished.toInstant().toString());
       } else {
         vm.put("finishedMs", 0);
         vm.put("finished", "");

--- a/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
+++ b/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
@@ -70,7 +70,8 @@ public class ConversionJob {
   public static final String PN_TEMPLATE_RULES = "templateRules";
   public static final String PN_COMPONENT_RULES = "componentRules";
   public static final String PN_POLICY_RULES = "policyRules";
-  public static final String PN_TARGET_PATH = "targetPath";
+  public static final String PN_SOURCE_ROOT = "sourceRoot";
+  public static final String PN_TARGET_ROOT = "targetRoot";
   public static final String PN_CONF_PATH = "confPath";
   public static final String PN_INITIATOR = "startedBy";
   public static final String PN_PAGE_HANDLING = "pageHandling";

--- a/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
+++ b/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
@@ -73,7 +73,7 @@ public class ConversionJob {
   public static final String PN_TARGET_PATH = "targetPath";
   public static final String PN_CONF_PATH = "confPath";
   public static final String PN_INITIATOR = "startedBy";
-  public static final String PN_REPROCESS = "reprocess";
+  public static final String PN_PAGE_HANDLING = "pageHandling";
   public static final String PN_PRE_MODERNIZE_VERSION = "cq:premodernizeVersion";
   public static final String PN_TYPE = "type";
   public static final String PN_FINISHED = "finished";
@@ -182,6 +182,12 @@ public class ConversionJob {
     public String getTopic() {
       return this.topic;
     }
+  }
+
+  public enum PageHandling {
+    NONE,
+    RESTORE,
+    COPY
   }
 
   public enum Status {

--- a/core/src/main/java/com/adobe/aem/modernize/servlet/ScheduleConversionJobServlet.java
+++ b/core/src/main/java/com/adobe/aem/modernize/servlet/ScheduleConversionJobServlet.java
@@ -176,8 +176,8 @@ public class ScheduleConversionJobServlet extends SlingAllMethodsServlet {
         throw new AccessDeniedException(data.getConfPath());
       }
 
-      if (StringUtils.isNotBlank(data.getTargetPath()) && !acm.hasPrivileges(data.getTargetPath(), privs)) {
-        throw new AccessDeniedException(data.getTargetPath());
+      if (StringUtils.isNotBlank(data.getTargetRoot()) && !acm.hasPrivileges(data.getTargetRoot(), privs)) {
+        throw new AccessDeniedException(data.getTargetRoot());
       }
 
     } catch (RepositoryException e) {
@@ -239,7 +239,8 @@ public class ScheduleConversionJobServlet extends SlingAllMethodsServlet {
     node.setProperty(PN_POLICY_RULES, requestData.getPolicyRules());
     node.setProperty(PN_TYPE, requestData.getType().toString());
     node.setProperty(PN_CONF_PATH, requestData.getConfPath());
-    node.setProperty(PN_TARGET_PATH, requestData.getTargetPath());
+    node.setProperty(PN_SOURCE_ROOT, requestData.getSourceRoot());
+    node.setProperty(PN_TARGET_ROOT, requestData.getTargetRoot());
     node.setProperty(PN_PAGE_HANDLING, requestData.getPageHandling().name());
     node.setProperty(PN_OVERWRITE, requestData.isOverwrite());
     node.setProperty(PN_INITIATOR, userId);
@@ -285,7 +286,8 @@ public class ScheduleConversionJobServlet extends SlingAllMethodsServlet {
     private String[] componentRules;
     private String[] policyRules;
     private String confPath;
-    private String targetPath;
+    private String sourceRoot;
+    private String targetRoot;
     private boolean overwrite;
     private PageHandling pageHandling = PageHandling.NONE;
     private Type type;

--- a/core/src/main/java/com/adobe/aem/modernize/servlet/ScheduleConversionJobServlet.java
+++ b/core/src/main/java/com/adobe/aem/modernize/servlet/ScheduleConversionJobServlet.java
@@ -240,7 +240,7 @@ public class ScheduleConversionJobServlet extends SlingAllMethodsServlet {
     node.setProperty(PN_TYPE, requestData.getType().toString());
     node.setProperty(PN_CONF_PATH, requestData.getConfPath());
     node.setProperty(PN_TARGET_PATH, requestData.getTargetPath());
-    node.setProperty(PN_REPROCESS, requestData.isReprocess());
+    node.setProperty(PN_PAGE_HANDLING, requestData.getPageHandling().name());
     node.setProperty(PN_OVERWRITE, requestData.isOverwrite());
     node.setProperty(PN_INITIATOR, userId);
     node.setProperty(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, ConversionJob.RESOURCE_TYPE);
@@ -287,7 +287,7 @@ public class ScheduleConversionJobServlet extends SlingAllMethodsServlet {
     private String confPath;
     private String targetPath;
     private boolean overwrite;
-    private boolean reprocess;
+    private PageHandling pageHandling = PageHandling.NONE;
     private Type type;
   }
 

--- a/core/src/test/java/com/adobe/aem/modernize/impl/RewriteUtilsTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/impl/RewriteUtilsTest.java
@@ -86,9 +86,4 @@ public class RewriteUtilsTest {
     assertEquals("<a href=&quot;/content/test/subpath&quot>Link</a>", property.getString(), "Longer path Rich Text Value");
   }
 
-  @Test
-  public void calcNewPath() {
-    assertEquals("/content/foo/bar", RewriteUtils.calcNewPath("/not/foo/bar", "/content"));
-    assertEquals("/content/foo/bar/baz", RewriteUtils.calcNewPath("/not/foo/bar/baz", "/content"));
-  }
 }

--- a/core/src/test/java/com/adobe/aem/modernize/job/FullConversionJobExecutorTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/job/FullConversionJobExecutorTest.java
@@ -219,6 +219,10 @@ public class FullConversionJobExecutorTest {
         assertNotNull(desc);
         return revision;
       }
+      @Mock
+      public Page copy(Page page, String dest, String before, boolean shallow, boolean resolve, boolean commit) {
+        return page;
+      }
     };
     new MockUp<R>() {
       @Mock
@@ -358,10 +362,6 @@ public class FullConversionJobExecutorTest {
         return rr.getResource(path).adaptTo(Page.class);
       }
 
-      @Mock
-      public Page copy(Page page, String dest, String before, boolean shallow, boolean resolve, boolean commit) {
-        return page;
-      }
     };
     new MockUp<R>() {
       @Mock

--- a/core/src/test/java/com/adobe/aem/modernize/job/FullConversionJobExecutorTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/job/FullConversionJobExecutorTest.java
@@ -221,6 +221,8 @@ public class FullConversionJobExecutorTest {
       }
       @Mock
       public Page copy(Page page, String dest, String before, boolean shallow, boolean resolve, boolean commit) {
+        String path = page.getPath().replace("/content/test", "/content/newpath/with/extra/tokens");
+        assertEquals(path, dest, "New page path correct");
         return page;
       }
     };

--- a/core/src/test/java/com/adobe/aem/modernize/servlet/ScheduleConversionJobServletTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/servlet/ScheduleConversionJobServletTest.java
@@ -324,6 +324,8 @@ public class ScheduleConversionJobServletTest {
     ScheduleConversionJobServlet.RequestData requestData = buildJobData();
     requestData.setType(ConversionJob.Type.FULL);
     requestData.setPageHandling(RESTORE);
+    requestData.setSourceRoot("/content/test/source");
+    requestData.setTargetRoot("/content/test/target");
     Map<String, Object> params = new HashMap<>();
     params.put("data", new ObjectMapper().writeValueAsString(requestData));
     request.setParameterMap(params);
@@ -364,6 +366,8 @@ public class ScheduleConversionJobServletTest {
     assertEquals(ConversionJob.RESOURCE_TYPE, serviceSession.getProperty(path + "/" + JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY).getString(), "Resource type was set");
     assertEquals(JOB_TITLE, serviceSession.getProperty(path + "/" + ConversionJob.PN_TITLE).getString(), "Title was set");
     assertEquals(RESTORE.name(), serviceSession.getProperty(path + "/" + ConversionJob.PN_PAGE_HANDLING).getString(), "Page handling was set");
+    assertEquals("/content/test/source", serviceSession.getProperty(path + "/" + ConversionJob.PN_SOURCE_ROOT).getString(), "Source copy path set");
+    assertEquals("/content/test/target", serviceSession.getProperty(path + "/" + ConversionJob.PN_TARGET_ROOT).getString(), "Target copy path set");
     assertEquals(userId, serviceSession.getProperty(path + "/" + ConversionJob.PN_INITIATOR).getString(), "Initiated by was set");
     assertTrue(serviceSession.propertyExists(path + "/" + ConversionJob.PN_TEMPLATE_RULES), "Template rules were set.");
     assertTrue(serviceSession.propertyExists(path + "/" + ConversionJob.PN_COMPONENT_RULES), "Component rules were set.");

--- a/core/src/test/java/com/adobe/aem/modernize/servlet/ScheduleConversionJobServletTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/servlet/ScheduleConversionJobServletTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.BundleContext;
 import static org.apache.sling.api.SlingHttpServletResponse.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static com.adobe.aem.modernize.model.ConversionJob.PageHandling.*;
 
 @ExtendWith(SlingContextExtension.class)
 public class ScheduleConversionJobServletTest {
@@ -322,6 +323,7 @@ public class ScheduleConversionJobServletTest {
 
     ScheduleConversionJobServlet.RequestData requestData = buildJobData();
     requestData.setType(ConversionJob.Type.FULL);
+    requestData.setPageHandling(RESTORE);
     Map<String, Object> params = new HashMap<>();
     params.put("data", new ObjectMapper().writeValueAsString(requestData));
     request.setParameterMap(params);
@@ -361,6 +363,7 @@ public class ScheduleConversionJobServletTest {
     assertTrue(serviceSession.nodeExists(path + "/buckets/bucket0"), "Bucket 2 was created");
     assertEquals(ConversionJob.RESOURCE_TYPE, serviceSession.getProperty(path + "/" + JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY).getString(), "Resource type was set");
     assertEquals(JOB_TITLE, serviceSession.getProperty(path + "/" + ConversionJob.PN_TITLE).getString(), "Title was set");
+    assertEquals(RESTORE.name(), serviceSession.getProperty(path + "/" + ConversionJob.PN_PAGE_HANDLING).getString(), "Page handling was set");
     assertEquals(userId, serviceSession.getProperty(path + "/" + ConversionJob.PN_INITIATOR).getString(), "Initiated by was set");
     assertTrue(serviceSession.propertyExists(path + "/" + ConversionJob.PN_TEMPLATE_RULES), "Template rules were set.");
     assertTrue(serviceSession.propertyExists(path + "/" + ConversionJob.PN_COMPONENT_RULES), "Component rules were set.");
@@ -415,6 +418,7 @@ public class ScheduleConversionJobServletTest {
     List<Map<String, Object>> jobProperties = new ArrayList<>();
     ScheduleConversionJobServlet.RequestData requestData = buildJobData();
     requestData.setType(ConversionJob.Type.FULL);
+    requestData.setPageHandling(RESTORE);
     Map<String, Object> params = new HashMap<>();
     params.put("data", new ObjectMapper().writeValueAsString(requestData));
     request.setParameterMap(params);

--- a/core/src/test/java/com/adobe/aem/modernize/structure/job/PageStructureJobExecutorTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/structure/job/PageStructureJobExecutorTest.java
@@ -145,6 +145,8 @@ public class PageStructureJobExecutorTest {
       }
       @Mock
       public Page copy(Page page, String dest, String before, boolean shallow, boolean resolve, boolean commit) {
+        String path = page.getPath().replace("/content/test", "/content/newpath/with/extra/tokens");
+        assertEquals(path, dest, "New page path correct");
         return page;
       }
     };

--- a/core/src/test/java/com/adobe/aem/modernize/structure/job/PageStructureJobExecutorTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/structure/job/PageStructureJobExecutorTest.java
@@ -143,6 +143,10 @@ public class PageStructureJobExecutorTest {
         assertNotNull(desc);
         return revision;
       }
+      @Mock
+      public Page copy(Page page, String dest, String before, boolean shallow, boolean resolve, boolean commit) {
+        return page;
+      }
     };
 
     new Expectations() {{
@@ -191,10 +195,6 @@ public class PageStructureJobExecutorTest {
           node.getProperty(PN_PRE_MODERNIZE_VERSION).remove();
         }
         return context.resourceResolver().getResource(path).adaptTo(Page.class);
-      }
-      @Mock
-      public Page copy(Page page, String dest, String before, boolean shallow, boolean resolve, boolean commit) {
-        return page;
       }
     };
 

--- a/core/src/test/resources/job/full-job-data.json
+++ b/core/src/test/resources/job/full-job-data.json
@@ -4,6 +4,8 @@
     "jcr:title": "Test",
     "type": "FULL",
     "confPath": "/conf/test",
+    "pageHandling": "COPY",
+    "targetPath": "/content/newpath",
     "componentRules": [
       "/var/aem-modernize/rules/component/title"
     ],
@@ -29,8 +31,7 @@
     "jcr:title": "Test",
     "type": "FULL",
     "confPath": "/conf/test",
-    "targetPath": "/content/newpath",
-    "reprocess": true,
+    "pageHandling": "RESTORE",
     "overwrite": true,
     "componentRules": [
       "/var/aem-modernize/rules/component/title"

--- a/core/src/test/resources/job/full-job-data.json
+++ b/core/src/test/resources/job/full-job-data.json
@@ -5,7 +5,8 @@
     "type": "FULL",
     "confPath": "/conf/test",
     "pageHandling": "COPY",
-    "targetPath": "/content/newpath",
+    "sourceRoot": "/content/test",
+    "targetRoot": "/content/newpath/with/extra/tokens",
     "componentRules": [
       "/var/aem-modernize/rules/component/title"
     ],

--- a/core/src/test/resources/job/structure-job-data.json
+++ b/core/src/test/resources/job/structure-job-data.json
@@ -6,7 +6,8 @@
     "componentRules": [],
     "policyRules": [],
     "pageHandling": "COPY",
-    "targetPath": "/content/newpath",
+    "sourceRoot": "/content/test",
+    "targetRoot": "/content/newpath/with/extra/tokens",
     "templateRules": [
       "com.adobe.aem.modernize.structure.impl.rule.PageRewriteRule.first-page",
       "com.adobe.aem.modernize.structure.impl.rule.PageRewriteRule.second-page"

--- a/core/src/test/resources/job/structure-job-data.json
+++ b/core/src/test/resources/job/structure-job-data.json
@@ -5,6 +5,8 @@
     "type": "STRUCTURE",
     "componentRules": [],
     "policyRules": [],
+    "pageHandling": "COPY",
+    "targetPath": "/content/newpath",
     "templateRules": [
       "com.adobe.aem.modernize.structure.impl.rule.PageRewriteRule.first-page",
       "com.adobe.aem.modernize.structure.impl.rule.PageRewriteRule.second-page"
@@ -21,10 +23,10 @@
   },
   "reprocess": {
     "jcr:primaryType": "nt:unstructured",
-    "targetPath": "/content/newpath",
     "reprocess": true,
     "jcr:title": "Test",
     "type": "STRUCTURE",
+    "pageHandling": "RESTORE",
     "componentRules": [],
     "policyRules": [],
     "templateRules": [

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/component/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/component/job/create/.content.xml
@@ -120,7 +120,7 @@
                     <primary jcr:primaryType="nt:unstructured">
                       <add jcr:primaryType="nt:unstructured"
                            sling:resourceType="granite/ui/components/coral/foundation/button"
-                           granite:class="foundation-collection-action foundation-picker-control"
+                           granite:class="foundation-collection-action foundation-picker-control aem-modernize-job-add-pages"
                            icon="add"
                            text="Add Pages"
                            variant="actionBar">

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/full/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/full/job/create/.content.xml
@@ -124,12 +124,24 @@
                                         fieldDescription="Select this option to copy the page before processing." />
                                 </items>
                               </pageHandling>
-                              <targetPath jcr:primaryType="nt:unstructured"
+                              <sourceRoot jcr:primaryType="nt:unstructured"
+                                          sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                          granite:rel="aem-modernize-job-source-root"
+                                          fieldLabel="Source Path"
+                                          fieldDescription="Each page will have this portion of the path replaced with the target location."
+                                          required="{Boolean}false"
+                                          multiple="{Boolean}false"
+                                          name="sourceRoot"
+                                          rootPath="/content"
+                                          filter="hierarchyNotFile"
+                                          disabled="{Boolean}true">
+                              </sourceRoot>
+                              <targetRoot jcr:primaryType="nt:unstructured"
                                           sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
                                           fieldLabel="Target Path"
                                           required="{Boolean}false"
                                           multiple="{Boolean}false"
-                                          name="targetPath"
+                                          name="targetRoot"
                                           rootPath="/content"
                                           filter="hierarchyNotFile"
                                           disabled="{Boolean}true"/>
@@ -194,7 +206,7 @@
                     <primary jcr:primaryType="nt:unstructured">
                       <add jcr:primaryType="nt:unstructured"
                            sling:resourceType="granite/ui/components/coral/foundation/button"
-                           granite:class="foundation-collection-action foundation-picker-control"
+                           granite:class="foundation-collection-action foundation-picker-control aem-modernize-job-add-pages"
                            icon="add"
                            text="Add Pages"
                            variant="actionBar">

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/full/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/full/job/create/.content.xml
@@ -81,7 +81,7 @@
                                    maximized="{Boolean}true">
                         <items jcr:primaryType="nt:unstructured">
                           <config jcr:primaryType="nt:unstructured"
-                                  jcr:title="General Configuration"
+                                  jcr:title="General"
                                   sling:resourceType="granite/ui/components/coral/foundation/form/fieldset"
                                   margin="{Boolean}true"
                                   maximized="{Boolean}true">
@@ -94,18 +94,36 @@
                             </items>
                           </config>
                           <pageConfig jcr:primaryType="nt:unstructured"
-                                      jcr:title="Page Configuration"
+                                      jcr:title="Page"
                                       sling:resourceType="granite/ui/components/coral/foundation/form/fieldset"
                                       margin="{Boolean}true"
                                       maximized="{Boolean}true">
                             <items jcr:primaryType="nt:unstructured">
-                              <reprocess jcr:primaryType="nt:unstructured"
-                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                         checked="{Boolean}false"
-                                         name="reprocess"
-                                         value="{Boolean}true"
-                                         text="Restore First?"
-                                         fieldDescription="Select this to restore page to state before last conversion attempt."/>
+                              <pageHandling jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/radiogroup"
+                                            granite:class="aem-modernize-page-handling"
+                                            fieldLabel="Page Handling"
+                                            name="pageHandling"
+                                            required="{Boolean}true"
+                                            vertical="{Boolean}false" >
+                                <items jcr:primaryType="nt:unstructured">
+                                  <none jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                        value="NONE"
+                                        text="None"
+                                        checked="{Boolean}true"/>
+                                  <restore jcr:primaryType="nt:unstructured"
+                                           sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                           value="RESTORE"
+                                           text="Restore"
+                                           fieldDescription="Select this to restore page to state before last Structure conversion."/>
+                                  <copy jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                        value="COPY"
+                                        text="Copy to Target"
+                                        fieldDescription="Select this option to copy the page before processing." />
+                                </items>
+                              </pageHandling>
                               <targetPath jcr:primaryType="nt:unstructured"
                                           sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
                                           fieldLabel="Target Path"
@@ -113,12 +131,12 @@
                                           multiple="{Boolean}false"
                                           name="targetPath"
                                           rootPath="/content"
-                                          fieldDescription="If specified, pages will be copied to this path before processing."
-                                          filter="hierarchyNotFile" />
+                                          filter="hierarchyNotFile"
+                                          disabled="{Boolean}true"/>
                             </items>
                           </pageConfig>
                           <policyConfig jcr:primaryType="nt:unstructured"
-                                        jcr:title="Policy Configuration"
+                                        jcr:title="Policy"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/fieldset"
                                         margin="{Boolean}true"
                                         maximized="{Boolean}true">

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/policy/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/policy/job/create/.content.xml
@@ -142,7 +142,7 @@
                     <primary jcr:primaryType="nt:unstructured">
                       <add jcr:primaryType="nt:unstructured"
                            sling:resourceType="granite/ui/components/coral/foundation/button"
-                           granite:class="foundation-collection-action foundation-picker-control"
+                           granite:class="foundation-collection-action foundation-picker-control aem-modernize-job-add-pages"
                            icon="add"
                            text="Add Pages"
                            variant="actionBar">

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/structure/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/structure/job/create/.content.xml
@@ -90,13 +90,31 @@
                                     name="name"
                                     fieldLabel="Job Name"
                                     required="{Boolean}true"/>
-                              <reprocess jcr:primaryType="nt:unstructured"
-                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                         checked="{Boolean}false"
-                                         name="reprocess"
-                                         value="{Boolean}true"
-                                         text="Restore First?"
-                                         fieldDescription="Select this to restore page to state before last Structure conversion attempt."/>
+                              <pageHandling jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/radiogroup"
+                                            granite:class="aem-modernize-page-handling"
+                                            fieldLabel="Page Handling"
+                                            name="pageHandling"
+                                            required="{Boolean}true"
+                                            vertical="{Boolean}false" >
+                                <items jcr:primaryType="nt:unstructured">
+                                  <none jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                        value="NONE"
+                                        text="None"
+                                        checked="{Boolean}true"/>
+                                  <restore jcr:primaryType="nt:unstructured"
+                                          sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                          value="RESTORE"
+                                          text="Restore"
+                                          fieldDescription="Select this to restore page to state before last Structure conversion."/>
+                                  <copy jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                        value="COPY"
+                                        text="Copy to Target"
+                                        fieldDescription="Select this option to copy the page before processing." />
+                                </items>
+                              </pageHandling>
                               <targetPath jcr:primaryType="nt:unstructured"
                                           sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
                                           fieldLabel="Target Path"
@@ -104,7 +122,8 @@
                                           multiple="{Boolean}false"
                                           name="targetPath"
                                           rootPath="/content"
-                                          filter="hierarchyNotFile" />
+                                          filter="hierarchyNotFile"
+                                          disabled="{Boolean}true"/>
                             </items>
                           </config>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/structure/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/structure/job/create/.content.xml
@@ -115,12 +115,23 @@
                                         fieldDescription="Select this option to copy the page before processing." />
                                 </items>
                               </pageHandling>
-                              <targetPath jcr:primaryType="nt:unstructured"
+                              <sourceRoot jcr:primaryType="nt:unstructured"
+                                          sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                          granite:rel="aem-modernize-job-source-root"
+                                          fieldLabel="Source Path"
+                                          fieldDescription="Each page will have this portion of the path replaced with the target location."
+                                          required="{Boolean}false"
+                                          multiple="{Boolean}false"
+                                          name="sourceRoot"
+                                          rootPath="/content"
+                                          filter="hierarchyNotFile"
+                                          disabled="{Boolean}true"/>
+                              <targetRoot jcr:primaryType="nt:unstructured"
                                           sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
                                           fieldLabel="Target Path"
                                           required="{Boolean}false"
                                           multiple="{Boolean}false"
-                                          name="targetPath"
+                                          name="targetRoot"
                                           rootPath="/content"
                                           filter="hierarchyNotFile"
                                           disabled="{Boolean}true"/>
@@ -154,7 +165,7 @@
                     <primary jcr:primaryType="nt:unstructured">
                       <add jcr:primaryType="nt:unstructured"
                            sling:resourceType="granite/ui/components/coral/foundation/button"
-                           granite:class="foundation-collection-action foundation-picker-control"
+                           granite:class="foundation-collection-action foundation-picker-control aem-modernize-job-add-pages"
                            icon="add"
                            text="Add Pages"
                            variant="actionBar">


### PR DESCRIPTION
## Description

This change will now allow for copying the page _as is_. OR restoring the page and processing the restored page.

## Motivation and Context

Due to how handling of processing a page occurs, either restoring the page to pre-modernize content OR copying is supported. If both are executed, then what occurs is the page is restored, then the restored page is copied to the new location. This leaves the restored page in the original location.

More fine tuning can be managed by users manually restoring pages to perform a copy, if that is what is desired.

## How Has This Been Tested?

Added unit tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
