### PR TITLE
Fix issues with RepoInit on AEM instances without /etc/designs

### DIFF
--- a/ui.config/src/main/content/jcr_root/apps/aem-modernize/osgiconfig/config.author.dev/org.apache.sling.jcr.repoinit.RepositoryInitializer-aem-modernize.config
+++ b/ui.config/src/main/content/jcr_root/apps/aem-modernize/osgiconfig/config.author.dev/org.apache.sling.jcr.repoinit.RepositoryInitializer-aem-modernize.config
@@ -2,7 +2,9 @@ scripts=["
 create path /var/aem-modernize(sling:Folder)
 create path /var/aem-modernize/job-data(sling:Folder)
 
-# user to invalidate cached redirects on change
+# Cover any missing paths on CS
+create path /etc/designs(sling:Folder)
+
 create service user aem-modernize-schedule-job-service with path system/aem-modernize
 set ACL for aem-modernize-schedule-job-service
     allow jcr:read on /

--- a/ui.config/src/main/content/jcr_root/apps/aem-modernize/osgiconfig/config.author.prod/org.apache.sling.jcr.repoinit.RepositoryInitializer-aem-modernize.config
+++ b/ui.config/src/main/content/jcr_root/apps/aem-modernize/osgiconfig/config.author.prod/org.apache.sling.jcr.repoinit.RepositoryInitializer-aem-modernize.config
@@ -1,0 +1,59 @@
+scripts=["
+create path /var/aem-modernize(sling:Folder)
+create path /var/aem-modernize/job-data(sling:Folder)
+
+# Cover any missing paths on CS
+create path /etc/designs(sling:Folder)
+
+create service user aem-modernize-schedule-job-service with path system/aem-modernize
+set ACL for aem-modernize-schedule-job-service
+    allow jcr:read on /
+    allow jcr:readAccessControl on /content,/conf,/etc
+    allow rep:write on /var/aem-modernize/job-data
+end
+
+create service user aem-modernize-convert-service with path system/aem-modernize
+set ACL for aem-modernize-convert-service
+    allow jcr:read on /
+    allow rep:write on /etc/designs
+    allow rep:write on /conf
+    allow rep:write on /content
+    allow jcr:versionManagement on /content
+    allow rep:write on /var/aem-modernize/job-data
+end
+
+create path /apps/aem-modernize(nt:unstructured)
+create path /apps/aem-modernize/content(nt:unstructured)
+create path /apps/aem-modernize/content/component(nt:unstructured)
+create path /apps/aem-modernize/content/full(nt:unstructured)
+create path /apps/aem-modernize/content/job(nt:unstructured)
+create path /apps/aem-modernize/content/policy(nt:unstructured)
+create path /apps/aem-modernize/content/structure(nt:unstructured)
+
+
+create path /apps/cq(nt:unstructured)
+create path /apps/cq/core(nt:unstructured)
+create path /apps/cq/core/content(nt:unstructured)
+create path /apps/cq/core/content/nav(nt:unstructured)
+create path /apps/cq/core/content/nav/tools(nt:unstructured)
+create path /apps/cq/core/content/nav/tools/aem-modernize(nt:unstructured)
+
+
+set ACL for everyone
+  deny jcr:all on /apps/aem-modernize/content/component
+  deny jcr:all on /apps/aem-modernize/content/full
+  deny jcr:all on /apps/aem-modernize/content/job
+  deny jcr:all on /apps/aem-modernize/content/policy
+  deny jcr:all on /apps/aem-modernize/content/structure
+  deny jcr:all on /apps/cq/core/content/nav/tools/aem-modernize
+end
+
+set ACL for administrators
+  allow jcr:all on /apps/aem-modernize/content/component
+  allow jcr:all on /apps/aem-modernize/content/full
+  allow jcr:all on /apps/aem-modernize/content/job
+  allow jcr:all on /apps/aem-modernize/content/policy
+  allow jcr:all on /apps/aem-modernize/content/structure
+  allow jcr:all on /apps/cq/core/content/nav/tools/aem-modernize
+end
+"]

--- a/ui.config/src/main/content/jcr_root/apps/aem-modernize/osgiconfig/config.author.stage/org.apache.sling.jcr.repoinit.RepositoryInitializer-aem-modernize.config
+++ b/ui.config/src/main/content/jcr_root/apps/aem-modernize/osgiconfig/config.author.stage/org.apache.sling.jcr.repoinit.RepositoryInitializer-aem-modernize.config
@@ -1,0 +1,59 @@
+scripts=["
+create path /var/aem-modernize(sling:Folder)
+create path /var/aem-modernize/job-data(sling:Folder)
+
+# Cover any missing paths on CS
+create path /etc/designs(sling:Folder)
+
+create service user aem-modernize-schedule-job-service with path system/aem-modernize
+set ACL for aem-modernize-schedule-job-service
+    allow jcr:read on /
+    allow jcr:readAccessControl on /content,/conf,/etc
+    allow rep:write on /var/aem-modernize/job-data
+end
+
+create service user aem-modernize-convert-service with path system/aem-modernize
+set ACL for aem-modernize-convert-service
+    allow jcr:read on /
+    allow rep:write on /etc/designs
+    allow rep:write on /conf
+    allow rep:write on /content
+    allow jcr:versionManagement on /content
+    allow rep:write on /var/aem-modernize/job-data
+end
+
+create path /apps/aem-modernize(nt:unstructured)
+create path /apps/aem-modernize/content(nt:unstructured)
+create path /apps/aem-modernize/content/component(nt:unstructured)
+create path /apps/aem-modernize/content/full(nt:unstructured)
+create path /apps/aem-modernize/content/job(nt:unstructured)
+create path /apps/aem-modernize/content/policy(nt:unstructured)
+create path /apps/aem-modernize/content/structure(nt:unstructured)
+
+
+create path /apps/cq(nt:unstructured)
+create path /apps/cq/core(nt:unstructured)
+create path /apps/cq/core/content(nt:unstructured)
+create path /apps/cq/core/content/nav(nt:unstructured)
+create path /apps/cq/core/content/nav/tools(nt:unstructured)
+create path /apps/cq/core/content/nav/tools/aem-modernize(nt:unstructured)
+
+
+set ACL for everyone
+  deny jcr:all on /apps/aem-modernize/content/component
+  deny jcr:all on /apps/aem-modernize/content/full
+  deny jcr:all on /apps/aem-modernize/content/job
+  deny jcr:all on /apps/aem-modernize/content/policy
+  deny jcr:all on /apps/aem-modernize/content/structure
+  deny jcr:all on /apps/cq/core/content/nav/tools/aem-modernize
+end
+
+set ACL for administrators
+  allow jcr:all on /apps/aem-modernize/content/component
+  allow jcr:all on /apps/aem-modernize/content/full
+  allow jcr:all on /apps/aem-modernize/content/job
+  allow jcr:all on /apps/aem-modernize/content/policy
+  allow jcr:all on /apps/aem-modernize/content/structure
+  allow jcr:all on /apps/cq/core/content/nav/tools/aem-modernize
+end
+"]


### PR DESCRIPTION
## Description

Use environment specific runmode for repo init configs; also enforce `/etc/designs` node creation.

## Related Issue

Issue #73 


## How Has This Been Tested?

Manually tested on latest SDK

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
