### PR TITLE
Disable responsive grid of Column Control rewrite

### DIFF
--- a/core/src/main/java/com/adobe/aem/modernize/component/impl/rule/ColumnControlRewriteRule.java
+++ b/core/src/main/java/com/adobe/aem/modernize/component/impl/rule/ColumnControlRewriteRule.java
@@ -418,8 +418,8 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
       columnControlResourceType = PROP_RESOURCE_TYPE_DEFAULT;
     }
 
-    String type = config.grid_type();
-    isResponsive = !StringUtils.equals(PROP_CONTAINER_TYPE, type);
+//    String type = config.grid_type();
+    isResponsive = false; // !StringUtils.equals(PROP_CONTAINER_TYPE, type);
 
     containerResourceType = config.container_resourceType();
     if (!isResponsive) {
@@ -477,15 +477,15 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
     )
     String column_control_resourceType() default PROP_RESOURCE_TYPE_DEFAULT;
 
-    @AttributeDefinition(
-        name = "Conversion Type",
-        description = "Type of structure to convert to: RESPONSIVE will arrange column contents in parent responsive grid. CONTAINER will replace each column with a container.",
-        options = {
-            @Option(label = "Responsive", value = PROP_RESPONSIVE_TYPE),
-            @Option(label = "Container", value = PROP_CONTAINER_TYPE),
-        }
-    )
-    String grid_type() default PROP_RESPONSIVE_TYPE;
+//    @AttributeDefinition(
+//        name = "Conversion Type",
+//        description = "Type of structure to convert to: RESPONSIVE will arrange column contents in parent responsive grid. CONTAINER will replace each column with a container.",
+//        options = {
+//            @Option(label = "Responsive", value = PROP_RESPONSIVE_TYPE),
+//            @Option(label = "Container", value = PROP_CONTAINER_TYPE),
+//        }
+//    )
+//    String grid_type() default PROP_RESPONSIVE_TYPE;
 
     @AttributeDefinition(
         name = "Container ResourceType",

--- a/core/src/test/java/com/adobe/aem/modernize/component/impl/rule/ColumnControlRewriteRuleTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/component/impl/rule/ColumnControlRewriteRuleTest.java
@@ -41,6 +41,7 @@ import com.day.cq.wcm.api.NameConstants;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static com.adobe.aem.modernize.component.impl.rule.ColumnControlRewriteRule.*;
@@ -84,30 +85,36 @@ public class ColumnControlRewriteRuleTest {
     assertThrows(RuntimeException.class, () -> context.registerInjectActivateService(new ColumnControlRewriteRule(), props), "Missing layout");
 
     props.clear();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "foo;cq-colctrl-lt0");
     assertThrows(RuntimeException.class, () -> context.registerInjectActivateService(new ColumnControlRewriteRule(), props), "Wrong layout format.");
 
     props.clear();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "2;cq-colctrl-lt0");
     assertThrows(RuntimeException.class, () -> context.registerInjectActivateService(new ColumnControlRewriteRule(), props), "Missing widths");
 
     props.clear();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "2;cq-colctrl-lt0");
     props.put("column.widths", new Object[] { "notlong", 5L });
     assertThrows(RuntimeException.class, () -> context.registerInjectActivateService(new ColumnControlRewriteRule(), props), "Widths wrong types.");
 
     props.clear();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "2;cq-colctrl-lt0");
     props.put("column.widths", new String[] {  "default=[3,3]", "tablet=[notLong,6]" });
     assertThrows(RuntimeException.class, () -> context.registerInjectActivateService(new ColumnControlRewriteRule(), props), "Widths wrong types.");
 
     props.clear();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "3;cq-colctrl-lt0");
     props.put("column.widths", new String[] {  "default=[3,3]", "tablet=[6,6]", "phone=[12,12]" });
     assertThrows(RuntimeException.class, () -> context.registerInjectActivateService(new ColumnControlRewriteRule(), props), "Incorrect width count.");
 
     // Defaults
     props.clear();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "2;cq-colctrl-lt0");
     props.put("column.widths", new String[] {  "default=[3,3]", "tablet=[6,6]", "phone=[12,12]" });
     ColumnControlRewriteRule rule = new ColumnControlRewriteRule();
@@ -131,6 +138,7 @@ public class ColumnControlRewriteRuleTest {
     ColumnControlRewriteRule rule = new ColumnControlRewriteRule();
     Resource root = context.resourceResolver().getResource("/content/test");
     final Map<String, Object> props = new HashMap<>();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "2;cq-colctrl-lt0");
     props.put("column.widths", new String[] { "default=[6,6]" });
     context.registerInjectActivateService(rule, props);
@@ -152,6 +160,7 @@ public class ColumnControlRewriteRuleTest {
   public void hasPattern() {
     ColumnControlRewriteRule rule = new ColumnControlRewriteRule();
     final Map<String, Object> props = new HashMap<>();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "2;cq-colctrl-lt0");
     props.put("column.widths", new String[] { "default=[6,6]" });
     context.registerInjectActivateService(rule, props);
@@ -178,6 +187,7 @@ public class ColumnControlRewriteRuleTest {
 
     ColumnControlRewriteRule rule = new ColumnControlRewriteRule();
     final Map<String, Object> props = new HashMap<>();
+    props.put("container.resourceType", "geodemo/components/container");
     props.put("layout.value", "2;cq-colctrl-lt0");
     props.put("column.widths", new String[] { "default=[6,6]" });
     context.registerInjectActivateService(rule, props);
@@ -197,6 +207,7 @@ public class ColumnControlRewriteRuleTest {
   }
 
   @Test
+  @Disabled
   public <R extends ResourceResolver, F extends ResourceResolverFactory>  void responsiveGridEqual() throws Exception {
 
     new MockUp<F>() {
@@ -254,6 +265,7 @@ public class ColumnControlRewriteRuleTest {
   }
 
   @Test
+  @Disabled
   public <R extends ResourceResolver, F extends ResourceResolverFactory>  void responsiveGridExtraFirst() throws Exception {
 
     new MockUp<F>() {
@@ -319,6 +331,7 @@ public class ColumnControlRewriteRuleTest {
   }
 
   @Test
+  @Disabled
   public <R extends ResourceResolver, F extends ResourceResolverFactory>  void responsiveGridExtraSecond() throws Exception {
 
     new MockUp<F>() {
@@ -465,6 +478,7 @@ public class ColumnControlRewriteRuleTest {
 
 
   @Test
+  @Disabled
   public <R extends ResourceResolver, F extends ResourceResolverFactory>  void responsiveGridExtraMiddle() throws Exception {
 
     new MockUp<F>() {

--- a/core/src/test/java/com/adobe/aem/modernize/component/impl/rule/ColumnControlTreeRewriteTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/component/impl/rule/ColumnControlTreeRewriteTest.java
@@ -37,6 +37,7 @@ import com.adobe.aem.modernize.component.impl.ComponentRewriteRuleServiceImpl;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static org.junit.jupiter.api.Assertions.*;
@@ -57,6 +58,7 @@ public class ColumnControlTreeRewriteTest {
 
 
   @Test
+  @Disabled
   public <R extends ResourceResolver, F extends ResourceResolverFactory> void test() throws Exception {
 
     new MockUp<F>() {


### PR DESCRIPTION
## Description

Disables the _responsive_ option of the ColumnControl rewrite rule.

## Motivation and Context

Due to how the rewriting a tree functions, when using the Responsive logic, the parent node order is not preserved. There becomes a conflict between the Column Control order being overwritten by the tree traversal.
