### PR TITLE
Fix reorder on Delete

### DIFF
--- a/core/src/main/java/com/adobe/aem/modernize/component/impl/ComponentRewriteRuleServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/modernize/component/impl/ComponentRewriteRuleServiceImpl.java
@@ -127,22 +127,24 @@ public class ComponentRewriteRuleServiceImpl extends AbstractRewriteRuleService<
     }
     for (RewriteRule rule : rewrites) {
       if (rule.matches(node)) {
-        rule.applyTo(node, new HashSet<>());
+        node = rule.applyTo(node, new HashSet<>());
         break;
       }
     }
-    // Previous not set - we should be first in the order - if previous and first item in list, we're the only child.
-    if (isOrdered && prevName == null) {
-      String nextName = parent.getNodes().nextNode().getName();
-      if (!nextName.equals(nodeName)) {
-        parent.orderBefore(nodeName, nextName);
+    if (node != null) {
+      // Previous not set - we should be first in the order - if previous and first item in list, we're the only child.
+      if (isOrdered && prevName == null) {
+        String nextName = parent.getNodes().nextNode().getName();
+        if (!nextName.equals(nodeName)) {
+          parent.orderBefore(nodeName, nextName);
+        }
+      } else {
+        NodeIterator siblings = parent.getNodes();
+        while (!siblings.nextNode().getName().equals(prevName)) {
+          // There has to be a better way to skip through a parent's children nodes.
+        }
+        parent.orderBefore(nodeName, siblings.nextNode().getName());
       }
-    } else {
-      NodeIterator siblings = parent.getNodes();
-      while (!siblings.nextNode().getName().equals(prevName)) {
-        // There has to be a better way to skip through a parent's children nodes.
-      }
-      parent.orderBefore(nodeName, siblings.nextNode().getName());
     }
   }
 

--- a/core/src/test/java/com/adobe/aem/modernize/component/impl/ComponentRewriteRuleServiceOakTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/component/impl/ComponentRewriteRuleServiceOakTest.java
@@ -57,6 +57,69 @@ public class ComponentRewriteRuleServiceOakTest {
   }
 
   @Test
+  public void testIssue_119_beginning() throws Exception {
+    Resource resource = context.resourceResolver().getResource("/content/test/all/jcr:content/simple");
+    Set<String> rule = Collections.singleton("/apps/aem-modernize/component/rules/deletes_simple");
+    componentRewriteRuleService.apply(resource, rule, false);
+    context.resourceResolver().commit();
+    String parentPath = "/content/test/all/jcr:content";
+    Resource parent = context.resourceResolver().getResource(parentPath);
+    Iterator<Resource> children = parent.getChildren().iterator();
+    assertEquals(parentPath + "/copyChildren", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/copyChildrenOrder", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/mapProperties", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteOptional", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteRanking", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteMapChildren", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteFinal", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteFinalOnReplacement", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteProperties", children.next().getPath(), "Order preserved");
+    assertFalse(children.hasNext(), "Children length");
+  }
+
+  @Test
+  public void testIssue_119_middle() throws Exception {
+    Resource resource = context.resourceResolver().getResource("/content/test/all/jcr:content/rewriteOptional");
+    Set<String> rule = Collections.singleton("/apps/aem-modernize/component/rules/deletes_middle");
+    componentRewriteRuleService.apply(resource, rule, false);
+    context.resourceResolver().commit();
+    String parentPath = "/content/test/all/jcr:content";
+    Resource parent = context.resourceResolver().getResource(parentPath);
+    Iterator<Resource> children = parent.getChildren().iterator();
+    assertEquals(parentPath + "/simple", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/copyChildren", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/copyChildrenOrder", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/mapProperties", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteRanking", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteMapChildren", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteFinal", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteFinalOnReplacement", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteProperties", children.next().getPath(), "Order preserved");
+    assertFalse(children.hasNext(), "Children length");
+  }
+
+  @Test
+  public void testIssue_119_end() throws Exception {
+    Resource resource = context.resourceResolver().getResource("/content/test/all/jcr:content/rewriteProperties");
+    Set<String> rule = Collections.singleton("/apps/aem-modernize/component/rules/deletes_end");
+    componentRewriteRuleService.apply(resource, rule, false);
+    context.resourceResolver().commit();
+    String parentPath = "/content/test/all/jcr:content";
+    Resource parent = context.resourceResolver().getResource(parentPath);
+    Iterator<Resource> children = parent.getChildren().iterator();
+    assertEquals(parentPath + "/simple", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/copyChildren", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/copyChildrenOrder", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/mapProperties", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteOptional", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteRanking", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteMapChildren", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteFinal", children.next().getPath(), "Order preserved");
+    assertEquals(parentPath + "/rewriteFinalOnReplacement", children.next().getPath(), "Order preserved");
+    assertFalse(children.hasNext(), "Children length");
+  }
+
+  @Test
   public void testShallowKeepsOrder() throws Exception {
     Resource resource = context.resourceResolver().getResource("/content/test/all/jcr:content/copyChildren");
     Set<String> rule = Collections.singleton("/apps/aem-modernize/component/rules/copyChildren");

--- a/core/src/test/resources/component/test-rules.json
+++ b/core/src/test/resources/component/test-rules.json
@@ -304,5 +304,47 @@
         "sling:resourceType": "geodemo/components/content/text"
       }
     }
+  },
+  "deletes_simple": {
+    "jcr:title": "Deletes Node Rule",
+    "jcr:primaryType": "nt:unstructured",
+    "patterns": {
+      "jcr:primaryType": "nt:unstructured",
+      "simple": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "aem-modernize/components/simple"
+      }
+    },
+    "replacement": {
+
+    }
+  },
+  "deletes_middle": {
+    "jcr:title": "Deletes Node Rule",
+    "jcr:primaryType": "nt:unstructured",
+    "patterns": {
+      "jcr:primaryType": "nt:unstructured",
+      "simple": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "aem-modernize/components/rewriteOptional"
+      }
+    },
+    "replacement": {
+
+    }
+  },
+  "deletes_end": {
+    "jcr:title": "Deletes Node Rule",
+    "jcr:primaryType": "nt:unstructured",
+    "patterns": {
+      "jcr:primaryType": "nt:unstructured",
+      "simple": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "aem-modernize/components/rewriteProperties"
+      }
+    },
+    "replacement": {
+
+    }
   }
 }


### PR DESCRIPTION

## Description

Check for the node to have been deleted before attempting to continue to order parent's children 

## Related Issue

Issue #119 

## How Has This Been Tested?

Manually tested. 

## Screenshots (if appropriate):

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
