### PR TITLE
"Like" based Rule Patterns

### DIFF
--- a/core/src/main/java/com/adobe/aem/modernize/rule/impl/AbstractRewriteRuleService.java
+++ b/core/src/main/java/com/adobe/aem/modernize/rule/impl/AbstractRewriteRuleService.java
@@ -20,6 +20,7 @@ package com.adobe.aem.modernize.rule.impl;
  * #L%
  */
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -79,7 +80,7 @@ public abstract class AbstractRewriteRuleService<S extends ServiceBasedRewriteRu
   @Override
   public Set<String> listRules(@NotNull Resource resource) {
     ResourceResolver rr = resource.getResourceResolver();
-    List<String> types = Collections.singletonList(resource.getResourceType());
+    List<String> types = listResourceTypes(resource);
     logger.debug("Finding rules for resource types: [{}]", types);
     final Set<String> rules = new HashSet<>(searchRules(rr, types));
     for (ServiceBasedRewriteRule s : getServiceRules()) {
@@ -138,6 +139,18 @@ public abstract class AbstractRewriteRuleService<S extends ServiceBasedRewriteRu
       logger.error("Unable to create NodeBasedRewriteRule", e);
     }
     return null;
+  }
+
+  private List<String> listResourceTypes(Resource resource) {
+    String type = resource.getResourceType();
+    List<String> types = new ArrayList<>();
+    int pos;
+    do {
+      types.add(type);
+      pos = PathUtils.getNextSlash(type, 0);
+      type = type.substring(pos + 1);
+    } while (pos >= 0);
+    return types;
   }
 
   private Set<String> searchRules(ResourceResolver rr, List<String> resourceTypes) {

--- a/core/src/main/java/com/adobe/aem/modernize/rule/impl/NodeBasedRewriteRule.java
+++ b/core/src/main/java/com/adobe/aem/modernize/rule/impl/NodeBasedRewriteRule.java
@@ -38,6 +38,7 @@ import javax.jcr.Value;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.commons.flat.TreeTraverser;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 
 import com.adobe.aem.modernize.RewriteException;
 import com.adobe.aem.modernize.rule.RewriteRule;
@@ -360,8 +361,13 @@ public class NodeBasedRewriteRule implements RewriteRule {
         return false;
       }
 
-      // property values on pattern and tree differ
-      if (!node.getProperty(name).getValue().equals(property.getValue())) {
+      // sling:resourceType is a special case - allow for multi-tenant component structures
+      if (JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY.equals(name)) {
+        if (!node.getProperty(name).getString().endsWith(property.getString())) {
+          return false;
+        }
+        // property values on pattern and tree differ
+      } else if (!node.getProperty(name).getValue().equals(property.getValue())) {
         return false;
       }
     }

--- a/core/src/main/java/com/adobe/aem/modernize/structure/rule/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/structure/rule/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.0.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package com.adobe.aem.modernize.structure.rule;
 
 /*-

--- a/core/src/test/java/com/adobe/aem/modernize/rule/impl/AbstractRewriteRuleServiceTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/rule/impl/AbstractRewriteRuleServiceTest.java
@@ -20,6 +20,7 @@ package com.adobe.aem.modernize.rule.impl;
  * #L%
  */
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -80,6 +81,20 @@ public class AbstractRewriteRuleServiceTest {
     context.load().json("/rewrite/test-simple-rules.json", "/apps/not-registered/rules");
     context.load().json("/rewrite/test-content.json", "/content/test/all/jcr:content");
   }
+
+
+  @Test
+  public void listResourceTypes() throws Exception {
+    Resource resource = context.resourceResolver().getResource("/content/test/all/jcr:content/simple");
+    Method method = AbstractRewriteRuleService.class.getDeclaredMethod("listResourceTypes", Resource.class);
+    method.setAccessible(true);
+    List<String> types = (List<String>) method.invoke(rewriteRuleService, resource);
+    assertEquals(3, types.size(), "Component types size");
+    assertEquals("aem-modernize/components/simple", types.get(0), "Full component resource type");
+    assertEquals("components/simple", types.get(1), "Partial component resource type");
+    assertEquals("simple", types.get(2), "Minimum component resource type");
+  }
+
 
   @Test
   public <R extends ResourceResolver> void testFindRulesQueryFails(
@@ -236,6 +251,10 @@ public class AbstractRewriteRuleServiceTest {
     paths.remove("/content/test/all/jcr:content/simpleTree");
     assertTrue(paths.contains("/content/test/all/jcr:content/aggregate"), "Rewrite final on replacement node rule.");
     paths.remove("/content/test/all/jcr:content/aggregate");
+    assertTrue(paths.contains("/content/test/all/jcr:content/modernizeSimpleLike"), "Simple Like rule");
+    paths.remove("/content/test/all/jcr:content/modernizeSimpleLike");
+    assertTrue(paths.contains("/content/test/all/jcr:content/customSimpleLike"), "Simple Like rule");
+    paths.remove("/content/test/all/jcr:content/customSimpleLike");
     assertTrue(paths.contains("/content/test/all/jcr:content/serviceTest"), "Service rule");
     paths.remove("/content/test/all/jcr:content/serviceTest");
     assertTrue(paths.isEmpty(), "Rule count");
@@ -326,6 +345,8 @@ public class AbstractRewriteRuleServiceTest {
     types.remove("aem-modernize/components/replacementRewriteFinal");
     assertTrue(types.contains("aem-modernize/components/rewriteProperties"), "rewriteProperties rule");
     types.remove("aem-modernize/components/rewriteProperties");
+    assertTrue(types.contains("components/simpleLike"), "simpleLike rule");
+    types.remove("components/simpleLike");
     assertTrue(types.isEmpty(), "Set result correct");
 
     ruleRoot = context.resourceResolver().getResource("/content/rules/aggregate");

--- a/core/src/test/java/com/adobe/aem/modernize/rule/impl/NodeBasedRewriteRuleTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/rule/impl/NodeBasedRewriteRuleTest.java
@@ -121,6 +121,10 @@ public class NodeBasedRewriteRuleTest {
     rule = new NodeBasedRewriteRule(rr.getResource(NEGATIVE_ROOT + "/missingChild").adaptTo(Node.class));
     assertFalse(rule.matches(content), "Missing child");
 
+    // Like operation check
+    rule = new NodeBasedRewriteRule(rr.getResource(NEGATIVE_ROOT + "/likeNotMatch").adaptTo(Node.class));
+    assertFalse(rule.matches(content), "Like Not Match");
+
     // Tree checks
     content = rr.getResource(CONTENT_ROOT + "/simpleTree").adaptTo(Node.class);
     rule = new NodeBasedRewriteRule(rr.getResource(NEGATIVE_ROOT + "/missingGrandChild").adaptTo(Node.class));
@@ -167,6 +171,17 @@ public class NodeBasedRewriteRuleTest {
   }
 
   @Test
+  public void testLikeMatches() throws Exception {
+    ResourceResolver rr = context.resourceResolver();
+    Node content = rr.getResource(CONTENT_ROOT + "/modernizeSimpleLike").adaptTo(Node.class);
+    RewriteRule rule = new NodeBasedRewriteRule(rr.getResource(SIMPLE_ROOT + "/simpleLike").adaptTo(Node.class));
+    assertTrue(rule.matches(content), "Simple Like comparison");
+
+    content = rr.getResource(CONTENT_ROOT + "/customSimpleLike").adaptTo(Node.class);
+    assertTrue(rule.matches(content), "Other Simple Like comparison");
+  }
+
+  @Test
   public void testReplacementRemoved() throws Exception {
     ResourceResolver rr = context.resourceResolver();
     Node content = rr.getResource(CONTENT_ROOT + "/remove").adaptTo(Node.class);
@@ -204,7 +219,7 @@ public class NodeBasedRewriteRuleTest {
     assertTrue(content.getSession().hasPendingChanges(), "Session has changes");
     content.getSession().save();
     Node updated = rr.getResource(CONTENT_ROOT + nodePath).adaptTo(Node.class);
-    assertEquals("core/wcm/components/title/v2/title", updated.getProperty("sling:resourceType").getString(), "Property was upadated");
+    assertEquals("core/wcm/components/title/v2/title", updated.getProperty("sling:resourceType").getString(), "Property was updated");
   }
 
   @Test

--- a/core/src/test/java/com/adobe/aem/modernize/structure/rule/PageRewriteRuleTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/structure/rule/PageRewriteRuleTest.java
@@ -30,7 +30,6 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.nodetype.NodeType;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;

--- a/core/src/test/resources/rewrite/test-content.json
+++ b/core/src/test/resources/rewrite/test-content.json
@@ -204,5 +204,23 @@
       "width": "340",
       "sling:resourceType": "foundation/components/image"
     }
+  },
+  "modernizeSimpleLike": {
+    "jcr:primaryType": "nt:unstructured",
+    "jcr:createdBy": "admin",
+    "jcr:title": "Strategic Consulting",
+    "jcr:lastModifiedBy": "admin",
+    "jcr:created": "Mon Aug 23 2010 22:12:08 GMT+0200",
+    "jcr:lastModified": "Wed Oct 27 2010 15:33:24 GMT-0400",
+    "sling:resourceType": "aem-modernize/components/simpleLike"
+  },
+  "customSimpleLike": {
+    "jcr:primaryType": "nt:unstructured",
+    "jcr:createdBy": "admin",
+    "jcr:title": "Strategic Consulting",
+    "jcr:lastModifiedBy": "admin",
+    "jcr:created": "Mon Aug 23 2010 22:12:08 GMT+0200",
+    "jcr:lastModified": "Wed Oct 27 2010 15:33:24 GMT-0400",
+    "sling:resourceType": "custom/components/simpleLike"
   }
 }

--- a/core/src/test/resources/rewrite/test-negative-rules.json
+++ b/core/src/test/resources/rewrite/test-negative-rules.json
@@ -399,5 +399,22 @@
         "sling:resourceType": "core/wcm/components/teaser/v1/teaser"
       }
     }
+  },
+  "likeNotMatch": {
+    "jcr:primaryType": "nt:unstructured",
+    "patterns": {
+      "jcr:primaryType": "nt:unstructured",
+      "simple": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "components/not-simple"
+      }
+    },
+    "replacement": {
+      "jcr:primaryType": "nt:unstructured",
+      "simple": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "core/wcm/components/title/v2/title"
+      }
+    }
   }
 }

--- a/core/src/test/resources/rewrite/test-simple-rules.json
+++ b/core/src/test/resources/rewrite/test-simple-rules.json
@@ -297,5 +297,23 @@
         }
       }
     }
+  },
+  "simpleLike": {
+    "jcr:title": "Simple Rule",
+    "jcr:primaryType": "nt:unstructured",
+    "patterns": {
+      "jcr:primaryType": "nt:unstructured",
+      "simple": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "components/simpleLike"
+      }
+    },
+    "replacement": {
+      "jcr:primaryType": "nt:unstructured",
+      "simple": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "core/wcm/components/title/v2/title"
+      }
+    }
   }
 }

--- a/docs/_includes/rules/configuration.html
+++ b/docs/_includes/rules/configuration.html
@@ -49,7 +49,30 @@ Each property of the pattern must be matched exactly for this rule to be applied
 * The primary node type
 * The `sling:resourceType` property's value.
 
-Patterns may also specify any other arbitrary properties, child nodes, or entire trees, to be matched. The rules for matching are universal - every property and node of the source node must match the expected rule's entire hierarchy, property for property, node for node - with one allowed exception: Optional children.
+Patterns may also specify any other arbitrary properties, child nodes, or entire trees to be matched. The rules for matching are universal - every property and node of the source node must match the expected rule's entire hierarchy, property for property, node for node - with one allowed exception: Optional children.
+
+#### "Like" Sling Resource Type Support (v2.1)
+
+With the release of v2.1, the `sling:resourceType` property allows configurations to use a "relative" path for matching. The patterns shown below will all match any component with the resource type `aem-modernize/components/text`:
+
+```xml
+<patterns jcr:primaryType="nt:unstructured">
+  <text jcr:primaryType="nt:unstructured"
+      sling:resourceType="aem-modernize/components/text"/>
+</patterns>
+
+<patterns jcr:primaryType="nt:unstructured">
+  <text jcr:primaryType="nt:unstructured"
+      sling:resourceType="components/text"/>
+</patterns>
+
+<patterns jcr:primaryType="nt:unstructured">
+  <text jcr:primaryType="nt:unstructured"
+      sling:resourceType="text"/>
+</patterns>
+```
+
+***Note:* that this does require more consideration in defining the patterns, as every node with any resource type that ends with `text` will have the rules applied. This may have negative, unintended effects**.  
 
 
 #### Rewrite Optional

--- a/docs/_pages/changes/v2.1.md
+++ b/docs/_pages/changes/v2.1.md
@@ -23,3 +23,56 @@ remove.components=["newslist","image"]
 rename.components=["par\=container/container","rightpar\=container_1659979946"]
 order.components=["header","carousel","container","container_1659979946","container:lead"]
 ```
+
+### "Like" Sling Resource Type Support
+
+This update allows node-based rule configurations to use a "relative" path for matching. The patterns shown below will all match any component with the resource type `aem-modernize/components/text`:
+
+```xml
+<patterns jcr:primaryType="nt:unstructured">
+  <text jcr:primaryType="nt:unstructured"
+      sling:resourceType="aem-modernize/components/text"/>
+</patterns>
+
+<patterns jcr:primaryType="nt:unstructured">
+  <text jcr:primaryType="nt:unstructured"
+      sling:resourceType="components/text"/>
+</patterns>
+
+<patterns jcr:primaryType="nt:unstructured">
+  <text jcr:primaryType="nt:unstructured"
+      sling:resourceType="text"/>
+</patterns>
+```
+
+Finding rules that may match is done by looking at the source resource type and checking rules against each sub-portion. Thus a resource type of `aem-modenrize/components/text`, will perform a lookup for rules that have a `sling:resourceType` pattern of:
+
+  * aem-modernize/components/text
+  * components/text
+  * text
+
+This means that [atterns should be very specific for other properties if the pattern's resource type is very generic. This is especially true for highly-used components such as `text`.
+
+#### Reasoning
+
+This was added as teams found that a single component was used across multiple tenants, but each tenant's rules were exactly the same. This required a rule to be defined as:
+
+```xml
+<patterns jcr:primaryType="nt:unstructured">
+  <text jcr:primaryType="nt:unstructured"
+      sling:resourceType="tenant-a/components/text"/>
+  <text jcr:primaryType="nt:unstructured"
+        sling:resourceType="tenant-b/components/text"/>
+  <text jcr:primaryType="nt:unstructured"
+        sling:resourceType="tenant-c/components/text"/>
+</patterns>
+```
+
+But can now be defined as:
+
+```xml
+<patterns jcr:primaryType="nt:unstructured">
+  <text jcr:primaryType="nt:unstructured"
+      sling:resourceType="components/text"/>
+</patterns>
+```


### PR DESCRIPTION
## Description

This update allows node-based rule configurations to use a "relative" path for matching. The patterns shown below will all match any component with the resource type `aem-modernize/components/text`:

```xml
<patterns jcr:primaryType="nt:unstructured">
  <text jcr:primaryType="nt:unstructured"
      sling:resourceType="aem-modernize/components/text"/>
</patterns>

<patterns jcr:primaryType="nt:unstructured">
  <text jcr:primaryType="nt:unstructured"
      sling:resourceType="components/text"/>
</patterns>

<patterns jcr:primaryType="nt:unstructured">
  <text jcr:primaryType="nt:unstructured"
      sling:resourceType="text"/>
</patterns>
```

## Motivation and Context

Teams found that a single component was used across multiple tenants, but each tenant's rules were exactly the same. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
