### PR TITLE
Adding support for Forms Conversion to aem modernize tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-
+**/.DS_Store
 
 ### Vault ###
 .vlt

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.aem</groupId>
         <artifactId>aem-modernize-tools</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -73,7 +73,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <!-- ====================================================================== -->
     <!-- P R O F I L E S                                                        -->
     <!-- ====================================================================== -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,7 +50,7 @@ Bundle-SymbolicName: com.adobe.aem.aem-modernize-tools.core
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+            <!-- <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
                 <configuration>
@@ -64,7 +64,7 @@ Bundle-SymbolicName: com.adobe.aem.aem-modernize-tools.core
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -172,7 +172,7 @@ Bundle-SymbolicName: com.adobe.aem.aem-modernize-tools.core
             <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
         </dependency>
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>aemaacsDeps</id>
@@ -280,7 +280,7 @@ Bundle-SymbolicName: com.adobe.aem.aem-modernize-tools.core
                 </dependency>
             </dependencies>
         </profile>
-        
+
         <profile>
             <id>generate-site-docs</id>
             <activation>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.aem</groupId>
         <artifactId>aem-modernize-tools</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>aem-modernize-tools.core</artifactId>
@@ -50,7 +50,7 @@ Bundle-SymbolicName: com.adobe.aem.aem-modernize-tools.core
                     </execution>
                 </executions>
             </plugin>
-            <!-- <plugin>
+            <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
                 <configuration>
@@ -64,7 +64,7 @@ Bundle-SymbolicName: com.adobe.aem.aem-modernize-tools.core
                         </goals>
                     </execution>
                 </executions>
-            </plugin> -->
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -172,7 +172,6 @@ Bundle-SymbolicName: com.adobe.aem.aem-modernize-tools.core
             <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
         </dependency>
     </dependencies>
-
     <profiles>
         <profile>
             <id>aemaacsDeps</id>
@@ -280,7 +279,6 @@ Bundle-SymbolicName: com.adobe.aem.aem-modernize-tools.core
                 </dependency>
             </dependencies>
         </profile>
-
         <profile>
             <id>generate-site-docs</id>
             <activation>

--- a/core/src/main/java/com/adobe/aem/modernize/component/impl/ComponentRewriteRuleServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/modernize/component/impl/ComponentRewriteRuleServiceImpl.java
@@ -105,6 +105,7 @@ public class ComponentRewriteRuleServiceImpl extends AbstractRewriteRuleService<
 
     try {
       String nodeName = node.getName();
+      String nodePath = node.getPath();
       String prevName = null;
       Node parent = node.getParent();
       boolean isOrdered = parent.getPrimaryNodeType().hasOrderableChildNodes();
@@ -118,8 +119,8 @@ public class ComponentRewriteRuleServiceImpl extends AbstractRewriteRuleService<
         }
       }
 
-      // Only order if node wasn't removed.
-      if (node != null && isOrdered) {
+      // Only order if node wasn't removed or modified
+      if (node != null && nodePath.equals(node.getPath()) && isOrdered) {
         orderParent(nodeName, prevName, parent);
       }
     } catch (RepositoryException e) {

--- a/core/src/main/java/com/adobe/aem/modernize/component/impl/ComponentRewriteRuleServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/modernize/component/impl/ComponentRewriteRuleServiceImpl.java
@@ -105,7 +105,6 @@ public class ComponentRewriteRuleServiceImpl extends AbstractRewriteRuleService<
 
     try {
       String nodeName = node.getName();
-      String nodePath = node.getPath();
       String prevName = null;
       Node parent = node.getParent();
       boolean isOrdered = parent.getPrimaryNodeType().hasOrderableChildNodes();
@@ -119,8 +118,8 @@ public class ComponentRewriteRuleServiceImpl extends AbstractRewriteRuleService<
         }
       }
 
-      // Only order if node wasn't removed or modified
-      if (node != null && nodePath.equals(node.getPath()) && isOrdered) {
+      // Only order if node wasn't removed
+      if (node != null && isOrdered) {
         orderParent(nodeName, prevName, parent);
       }
     } catch (RepositoryException e) {

--- a/core/src/main/java/com/adobe/aem/modernize/component/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/component/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.2.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package com.adobe.aem.modernize.component;
 
 /*-

--- a/core/src/main/java/com/adobe/aem/modernize/component/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/component/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.1.0")
+@org.osgi.annotation.versioning.Version("2.2.0")
 package com.adobe.aem.modernize.component;
 
 /*-
@@ -10,9 +10,9 @@ package com.adobe.aem.modernize.component;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/com/adobe/aem/modernize/form/job/FormConversionJobExecutor.java
+++ b/core/src/main/java/com/adobe/aem/modernize/form/job/FormConversionJobExecutor.java
@@ -1,4 +1,4 @@
-package com.adobe.aem.modernize.job;
+package com.adobe.aem.modernize.form.job;
 
 /*-
  * #%L
@@ -23,6 +23,7 @@ package com.adobe.aem.modernize.job;
 import com.adobe.aem.modernize.RewriteException;
 import com.adobe.aem.modernize.component.ComponentRewriteRuleService;
 import com.adobe.aem.modernize.impl.RewriteUtils;
+import com.adobe.aem.modernize.job.AbstractConversionJobExecutor;
 import com.adobe.aem.modernize.model.ConversionJob;
 import com.adobe.aem.modernize.model.ConversionJobBucket;
 import com.day.cq.commons.jcr.JcrUtil;

--- a/core/src/main/java/com/adobe/aem/modernize/form/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/form/package-info.java
@@ -1,11 +1,11 @@
 @org.osgi.annotation.versioning.Version("2.2.0")
-package com.adobe.aem.modernize.rule;
+package com.adobe.aem.modernize.form;
 
 /*-
  * #%L
  * AEM Modernize Tools - Core
  * %%
- * Copyright (C) 2019 - 2021 Adobe Inc.
+ * Copyright (C) 2019 - 2024 Adobe Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,3 +20,4 @@ package com.adobe.aem.modernize.rule;
  * limitations under the License.
  * #L%
  */
+

--- a/core/src/main/java/com/adobe/aem/modernize/job/FormConversionJobExecutor.java
+++ b/core/src/main/java/com/adobe/aem/modernize/job/FormConversionJobExecutor.java
@@ -1,0 +1,137 @@
+package com.adobe.aem.modernize.job;
+
+import com.adobe.aem.modernize.RewriteException;
+import com.adobe.aem.modernize.component.ComponentRewriteRuleService;
+import com.adobe.aem.modernize.impl.RewriteUtils;
+import com.adobe.aem.modernize.model.ConversionJob;
+import com.adobe.aem.modernize.model.ConversionJobBucket;
+import com.day.cq.commons.jcr.JcrUtil;
+import com.day.cq.wcm.api.NameConstants;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.WCMException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.event.jobs.Job;
+import org.apache.sling.event.jobs.consumer.JobExecutionContext;
+import org.apache.sling.event.jobs.consumer.JobExecutor;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static com.adobe.aem.modernize.model.ConversionJob.PageHandling.COPY;
+import static com.adobe.aem.modernize.model.ConversionJob.PageHandling.RESTORE;
+
+@Component(
+        service = { JobExecutor.class },
+        property = {
+                JobExecutor.PROPERTY_TOPICS + "=" + FormConversionJobExecutor.JOB_TOPIC
+        }
+)
+public class FormConversionJobExecutor extends AbstractConversionJobExecutor {
+    public static final String JOB_TOPIC = "com/adobe/aem/modernize/job/topic/convert/form";
+
+    private static final String AF_ROOT = "/content/forms/af";
+    private static final String DAM_ROOT = "/content/dam/formsanddocuments";
+
+    @Reference
+    private ComponentRewriteRuleService componentService;
+
+    @Reference
+    private ResourceResolverFactory resourceResolverFactory;
+
+    @Override
+    protected void doProcess(@NotNull Job job, @NotNull JobExecutionContext context, @NotNull ConversionJobBucket bucket) {
+        final ConversionJob.PageHandling pageHandling = getPageHandling(bucket);
+        String sourceRoot = getSourceRoot(bucket);
+        String targetRoot = getTargetRoot(bucket);
+
+        Resource resource = bucket.getResource();
+        ResourceResolver rr = resource.getResourceResolver();
+        PageManager pm = rr.adaptTo(PageManager.class);
+        Set<String> componentRules = getComponentRules(bucket);
+
+        List<String> paths = bucket.getPaths();
+        context.initProgress(paths.size(), -1);
+
+        for (String path : paths) {
+            Page page = pm.getPage(path);
+            if (page == null) {
+                bucket.getNotFound().add(path);
+                context.incrementProgressCount(1);
+                continue;
+            }
+
+            if (pageHandling == COPY && (StringUtils.isBlank(sourceRoot) || StringUtils.isBlank(targetRoot))) {
+                bucket.getFailed().add(path);
+                continue;
+            }
+
+            try {
+                if (pageHandling == RESTORE) {
+                    page = RewriteUtils.restore(pm, page);
+                }
+
+                RewriteUtils.createVersion(pm, page);
+
+                if (pageHandling == COPY) {
+                    // copy asset part for forms
+                    Node formAssetNode = rr.getResource(getFormsAssetPathFromPagePath(page.getPath())).adaptTo(Node.class);
+                    Node targetNode = rr.getResource(getFormsAssetPathFromPagePath(targetRoot)).adaptTo(Node.class);
+                    JcrUtil.copy(formAssetNode, targetNode, formAssetNode.getName());
+
+                    // copy page part for forms
+                    page = RewriteUtils.copyPage(pm, page, sourceRoot, targetRoot);
+                }
+
+                if (componentRules.isEmpty()) {
+                    context.log("No component rules found, skipping skipping component conversion.");
+                } else {
+                    componentService.apply(page.getContentResource(), componentRules, true);
+                    fixChildrenOrder(page);
+                }
+
+                bucket.getSuccess().add(path);
+            } catch (WCMException e) {
+                logger.error("Error occurred while trying to manage page versions.", e);
+                bucket.getFailed().add(path);
+            } catch (RewriteException e) {
+                logger.error("Conversion resulted in an error", e);
+                bucket.getFailed().add(path);
+            } catch (RepositoryException e) {
+                logger.error("Failed to copy forms asset node. Conversion resulted in an error", e);
+                bucket.getFailed().add(path);
+            }
+            context.incrementProgressCount(1);
+        }
+    }
+
+    @Override
+    protected ResourceResolverFactory getResourceResolverFactory() {
+        return resourceResolverFactory;
+    }
+
+    private void fixChildrenOrder(Page page) throws RewriteException {
+        Iterator<Page> children = page.listChildren();
+        if (children.hasNext()) {
+            Node node = page.adaptTo(Node.class);
+            try {
+                node.orderBefore(NameConstants.NN_CONTENT, children.next().getName());
+            } catch (RepositoryException e) {
+                throw new RewriteException("Unable to re-order page's JCR Content Node.", e);
+            }
+        }
+    }
+
+    private String getFormsAssetPathFromPagePath(String pagePath) {
+        return StringUtils.replace(pagePath, AF_ROOT, DAM_ROOT);
+    }
+}

--- a/core/src/main/java/com/adobe/aem/modernize/job/FormConversionJobExecutor.java
+++ b/core/src/main/java/com/adobe/aem/modernize/job/FormConversionJobExecutor.java
@@ -1,5 +1,25 @@
 package com.adobe.aem.modernize.job;
 
+/*-
+ * #%L
+ * AEM Modernize Tools - Core
+ * %%
+ * Copyright (C) 2019 - 2024 Adobe Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import com.adobe.aem.modernize.RewriteException;
 import com.adobe.aem.modernize.component.ComponentRewriteRuleService;
 import com.adobe.aem.modernize.impl.RewriteUtils;

--- a/core/src/main/java/com/adobe/aem/modernize/job/FormConversionJobExecutor.java
+++ b/core/src/main/java/com/adobe/aem/modernize/job/FormConversionJobExecutor.java
@@ -26,7 +26,6 @@ import com.adobe.aem.modernize.impl.RewriteUtils;
 import com.adobe.aem.modernize.model.ConversionJob;
 import com.adobe.aem.modernize.model.ConversionJobBucket;
 import com.day.cq.commons.jcr.JcrUtil;
-import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.WCMException;
@@ -43,7 +42,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -116,7 +114,6 @@ public class FormConversionJobExecutor extends AbstractConversionJobExecutor {
                     context.log("No component rules found, skipping skipping component conversion.");
                 } else {
                     componentService.apply(page.getContentResource(), componentRules, true);
-                    fixChildrenOrder(page);
                 }
 
                 bucket.getSuccess().add(path);
@@ -137,18 +134,6 @@ public class FormConversionJobExecutor extends AbstractConversionJobExecutor {
     @Override
     protected ResourceResolverFactory getResourceResolverFactory() {
         return resourceResolverFactory;
-    }
-
-    private void fixChildrenOrder(Page page) throws RewriteException {
-        Iterator<Page> children = page.listChildren();
-        if (children.hasNext()) {
-            Node node = page.adaptTo(Node.class);
-            try {
-                node.orderBefore(NameConstants.NN_CONTENT, children.next().getName());
-            } catch (RepositoryException e) {
-                throw new RewriteException("Unable to re-order page's JCR Content Node.", e);
-            }
-        }
     }
 
     private String getFormsAssetPathFromPagePath(String pagePath) {

--- a/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
+++ b/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
@@ -24,7 +24,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.adobe.aem.modernize.job.FormConversionJobExecutor;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.JobManager;
@@ -34,6 +33,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import com.adobe.aem.modernize.component.job.ComponentJobExecutor;
+import com.adobe.aem.modernize.form.job.FormConversionJobExecutor;
 import com.adobe.aem.modernize.job.FullConversionJobExecutor;
 import com.adobe.aem.modernize.policy.job.PolicyJobExecutor;
 import com.adobe.aem.modernize.structure.job.PageStructureJobExecutor;

--- a/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
+++ b/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
@@ -9,9 +9,7 @@ package com.adobe.aem.modernize.model;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
+++ b/core/src/main/java/com/adobe/aem/modernize/model/ConversionJob.java
@@ -9,9 +9,9 @@ package com.adobe.aem.modernize.model;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.adobe.aem.modernize.job.FormConversionJobExecutor;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.JobManager;
@@ -172,7 +173,8 @@ public class ConversionJob {
     FULL(FullConversionJobExecutor.JOB_TOPIC),
     COMPONENT(ComponentJobExecutor.JOB_TOPIC),
     STRUCTURE(PageStructureJobExecutor.JOB_TOPIC),
-    POLICY(PolicyJobExecutor.JOB_TOPIC);
+    POLICY(PolicyJobExecutor.JOB_TOPIC),
+    FORM(FormConversionJobExecutor.JOB_TOPIC);
 
     private final String topic;
 

--- a/core/src/main/java/com/adobe/aem/modernize/model/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/model/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.0.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package com.adobe.aem.modernize.model;
 
 /*-
@@ -10,9 +10,9 @@ package com.adobe.aem.modernize.model;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/com/adobe/aem/modernize/policy/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/policy/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.1.0")
+@org.osgi.annotation.versioning.Version("2.2.0")
 package com.adobe.aem.modernize.policy;
 
 /*-
@@ -10,9 +10,9 @@ package com.adobe.aem.modernize.policy;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/com/adobe/aem/modernize/policy/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/policy/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.2.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package com.adobe.aem.modernize.policy;
 
 /*-

--- a/core/src/main/java/com/adobe/aem/modernize/rule/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/rule/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.2.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package com.adobe.aem.modernize.rule;
 
 /*-

--- a/core/src/main/java/com/adobe/aem/modernize/servlet/AbstractRulesServlet.java
+++ b/core/src/main/java/com/adobe/aem/modernize/servlet/AbstractRulesServlet.java
@@ -1,7 +1,11 @@
 package com.adobe.aem.modernize.servlet;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 import javax.jcr.RepositoryException;
 import javax.servlet.ServletException;
 
@@ -36,7 +40,6 @@ import static javax.servlet.http.HttpServletResponse.*;
 public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractRulesServlet.class);
-
   protected static final String PARAM_REPROCESS = "reprocess";
   private static final String PARAM_PATH = "path";
 
@@ -64,7 +67,6 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
       writeResponse(response, SC_OK, data);
       return;
     }
-
     Set<String> paths = new HashSet<>();
     Set<RuleInfo> infos = foundPaths.stream()
         .map(p -> {
@@ -99,7 +101,6 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
     }
     return pageContent;
   }
-
   @Nullable
   protected Resource getOriginalPageContent(@NotNull Page page) {
     String versionId = page.getProperties().get(ConversionJob.PN_PRE_MODERNIZE_VERSION, String.class);
@@ -133,7 +134,6 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
           ValueMap vm = resource.adaptTo(ValueMap.class);
           if (vm != null &&
               StringUtils.isNotBlank(vm.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class))) {
-
             paths.add(resource.getPath());
           }
         }
@@ -168,10 +168,8 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
 
   @NotNull
   protected abstract Set<String> listPaths(@NotNull Map<String, String[]> requestParameters, @NotNull Page page);
-
   @NotNull
   protected abstract RewriteRuleService getRewriteRuleService();
-
   @Getter
   @Setter
   @NoArgsConstructor

--- a/core/src/main/java/com/adobe/aem/modernize/servlet/AbstractRulesServlet.java
+++ b/core/src/main/java/com/adobe/aem/modernize/servlet/AbstractRulesServlet.java
@@ -1,11 +1,7 @@
 package com.adobe.aem.modernize.servlet;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.jcr.RepositoryException;
 import javax.servlet.ServletException;
 
@@ -40,7 +36,7 @@ import static javax.servlet.http.HttpServletResponse.*;
 public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractRulesServlet.class);
-  
+
   protected static final String PARAM_REPROCESS = "reprocess";
   private static final String PARAM_PATH = "path";
 
@@ -68,7 +64,7 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
       writeResponse(response, SC_OK, data);
       return;
     }
-            
+
     Set<String> paths = new HashSet<>();
     Set<RuleInfo> infos = foundPaths.stream()
         .map(p -> {
@@ -103,7 +99,7 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
     }
     return pageContent;
   }
-  
+
   @Nullable
   protected Resource getOriginalPageContent(@NotNull Page page) {
     String versionId = page.getProperties().get(ConversionJob.PN_PRE_MODERNIZE_VERSION, String.class);
@@ -137,7 +133,7 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
           ValueMap vm = resource.adaptTo(ValueMap.class);
           if (vm != null &&
               StringUtils.isNotBlank(vm.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class))) {
-            
+
             paths.add(resource.getPath());
           }
         }
@@ -172,10 +168,10 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
 
   @NotNull
   protected abstract Set<String> listPaths(@NotNull Map<String, String[]> requestParameters, @NotNull Page page);
-  
+
   @NotNull
   protected abstract RewriteRuleService getRewriteRuleService();
-  
+
   @Getter
   @Setter
   @NoArgsConstructor

--- a/core/src/main/java/com/adobe/aem/modernize/servlet/AbstractRulesServlet.java
+++ b/core/src/main/java/com/adobe/aem/modernize/servlet/AbstractRulesServlet.java
@@ -67,6 +67,7 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
       writeResponse(response, SC_OK, data);
       return;
     }
+
     Set<String> paths = new HashSet<>();
     Set<RuleInfo> infos = foundPaths.stream()
         .map(p -> {
@@ -101,6 +102,7 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
     }
     return pageContent;
   }
+
   @Nullable
   protected Resource getOriginalPageContent(@NotNull Page page) {
     String versionId = page.getProperties().get(ConversionJob.PN_PRE_MODERNIZE_VERSION, String.class);
@@ -134,6 +136,7 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
           ValueMap vm = resource.adaptTo(ValueMap.class);
           if (vm != null &&
               StringUtils.isNotBlank(vm.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class))) {
+
             paths.add(resource.getPath());
           }
         }
@@ -168,8 +171,10 @@ public abstract class AbstractRulesServlet extends SlingSafeMethodsServlet {
 
   @NotNull
   protected abstract Set<String> listPaths(@NotNull Map<String, String[]> requestParameters, @NotNull Page page);
+
   @NotNull
   protected abstract RewriteRuleService getRewriteRuleService();
+
   @Getter
   @Setter
   @NoArgsConstructor

--- a/core/src/main/java/com/adobe/aem/modernize/structure/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/structure/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.2.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package com.adobe.aem.modernize.structure;
 
 /*-

--- a/core/src/main/java/com/adobe/aem/modernize/structure/package-info.java
+++ b/core/src/main/java/com/adobe/aem/modernize/structure/package-info.java
@@ -1,4 +1,4 @@
-@org.osgi.annotation.versioning.Version("2.1.0")
+@org.osgi.annotation.versioning.Version("2.2.0")
 package com.adobe.aem.modernize.structure;
 
 /*-
@@ -10,9 +10,9 @@ package com.adobe.aem.modernize.structure;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/test/java/com/adobe/aem/modernize/form/job/FormConversionJobExecutorTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/form/job/FormConversionJobExecutorTest.java
@@ -1,15 +1,18 @@
-package com.adobe.aem.modernize.job;
+package com.adobe.aem.modernize.form.job;
 
 import com.adobe.aem.modernize.RewriteException;
 import com.adobe.aem.modernize.component.ComponentRewriteRuleService;
 import com.adobe.aem.modernize.component.impl.ComponentRewriteRuleServiceImpl;
+import com.adobe.aem.modernize.form.job.FormConversionJobExecutor;
 import com.adobe.aem.modernize.model.ConversionJob;
 import com.adobe.aem.modernize.model.ConversionJobBucket;
-import com.day.cq.commons.jcr.JcrUtil;
 import com.day.cq.wcm.api.*;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
-import mockit.*;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.event.jobs.Job;
@@ -23,7 +26,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.adobe.aem.modernize.model.ConversionJob.JOB_DATA_LOCATION;
 import static com.adobe.aem.modernize.model.ConversionJob.PN_PRE_MODERNIZE_VERSION;

--- a/core/src/test/java/com/adobe/aem/modernize/job/FormConversionJobExecutorTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/job/FormConversionJobExecutorTest.java
@@ -1,0 +1,234 @@
+package com.adobe.aem.modernize.job;
+
+import com.adobe.aem.modernize.component.ComponentRewriteRuleService;
+import com.adobe.aem.modernize.component.impl.ComponentRewriteRuleServiceImpl;
+import com.adobe.aem.modernize.model.ConversionJob;
+import com.adobe.aem.modernize.model.ConversionJobBucket;
+import com.day.cq.wcm.api.*;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import mockit.*;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.event.jobs.Job;
+import org.apache.sling.event.jobs.consumer.JobExecutionContext;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import java.util.*;
+
+import static com.adobe.aem.modernize.model.ConversionJob.JOB_DATA_LOCATION;
+import static com.adobe.aem.modernize.model.ConversionJob.PN_PRE_MODERNIZE_VERSION;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(AemContextExtension.class)
+public class FormConversionJobExecutorTest {
+    private static final int pathCount = 2;
+    private static final String version = "987654321";
+    private final AemContext context = new AemContext(ResourceResolverType.JCR_OAK);
+    private final FormConversionJobExecutor executor = new FormConversionJobExecutor();
+    private final ComponentRewriteRuleService componentService = new ComponentRewriteRuleServiceImpl();
+
+    @Mocked
+    private Job job;
+
+    @Mocked
+    private JobExecutionContext jobExecutionContext;
+
+    @Mocked
+    private Revision revision;
+
+    @BeforeEach
+    public void beforeEach() {
+        context.load().json("/job/initial-form-content.json", "/content/forms/af/sourcefolder");
+        context.load().json("/job/initial-form-asset-content.json", "/content/dam/formsanddocuments/sourcefolder/initialform");
+        context.create().resource("/content/dam/formsanddocuments/targetfolder");
+        context.load().json("/job/form-job-data.json", JOB_DATA_LOCATION + "/form");
+        context.load().json("/job/component-job-data.json", ConversionJob.JOB_DATA_LOCATION + "/component");
+        context.load().json("/job/test-form-rules.json", "/var/aem-modernize/rules");
+
+
+        Map<String, Object> props = new HashMap<>();
+        props.put("search.paths", new String[] { "/var/aem-modernize/rules" });
+        context.registerInjectActivateService(componentService, props);
+        context.registerInjectActivateService(executor);
+    }
+
+    @Test
+    public void testPathsNotForm() {
+        final String path = ConversionJob.JOB_DATA_LOCATION + "/component/buckets/bucket0";
+        new Expectations() {{
+            jobExecutionContext.initProgress(3, -1);
+        }};
+        ResourceResolver rr = context.resourceResolver();
+        ConversionJobBucket bucket = rr.getResource(path).adaptTo(ConversionJobBucket.class);
+        executor.doProcess(job, jobExecutionContext, bucket);
+        List<String> notFound = bucket.getNotFound();
+        assertEquals(3, notFound.size(), "Not found list size");
+        assertTrue(notFound.contains("/content/test/first-page/jcr:content/component"), "Not found item");
+        assertTrue(notFound.contains("/content/test/second-page/jcr:content/component"), "Not found item");
+        assertTrue(notFound.contains("/content/test/not-found-page/jcr:content/component"), "Not found item");
+    }
+
+    @Test
+    public <P extends PageManager> void createVersionManagementFails() {
+        final String path = ConversionJob.JOB_DATA_LOCATION + "/form/noReprocess/buckets/bucket0";
+        ResourceResolver rr = context.resourceResolver();
+
+        new MockUp<P>() {
+            @Mock
+            public Revision createRevision(Page page, String label, String desc) throws WCMException {
+                throw new WCMException("Exception");
+            }
+
+            @Mock
+            public Page restore(String path, String id) throws WCMException {
+                throw new WCMException("Exception");
+            }
+        };
+
+        new Expectations() {{
+            jobExecutionContext.initProgress(pathCount, -1);
+            jobExecutionContext.incrementProgressCount(1);
+            times = pathCount;
+        }};
+
+        ConversionJobBucket bucket = rr.getResource(path).adaptTo(ConversionJobBucket.class);
+        executor.doProcess(job, jobExecutionContext, bucket);
+        List<String> failed = bucket.getFailed();
+        assertEquals(1, failed.size(), "Failed list size");
+        assertTrue(failed.contains("/content/forms/af/sourcefolder/initialform"), "Failed item");
+
+        List<String> notFound = bucket.getNotFound();
+        assertEquals(1, notFound.size(), "Not found list size");
+        assertTrue(notFound.contains("/content/forms/af/not-found-form"), "Not found item");
+    }
+
+    @Test
+    public <P extends PageManager> void doProcessNoReprocess() throws Exception {
+        final String path = ConversionJob.JOB_DATA_LOCATION + "/form/noReprocess/buckets/bucket0";
+        ResourceResolver rr = context.resourceResolver();
+
+        new MockUp<P>() {
+            @Mock
+            public Revision createRevision(Page page, String label, String desc) {
+                assertNotNull(page);
+                assertNotNull(label);
+                assertNotNull(desc);
+                return revision;
+            }
+            @Mock
+            public Page copy(Page page, String dest, String before, boolean shallow, boolean resolve, boolean commit) {
+                String path = page.getPath().replace("/content/forms/af/sourcefolder", "/content/forms/af/targetfolder");
+                assertEquals(path, dest, "New form path correct");
+                return page;
+            }
+        };
+
+        new Expectations() {{
+            jobExecutionContext.initProgress(pathCount, -1);
+            revision.getId();
+            result = version;
+            jobExecutionContext.incrementProgressCount(1);
+            times = pathCount;
+        }};
+
+        ConversionJobBucket bucket = rr.getResource(path).adaptTo(ConversionJobBucket.class);
+        executor.doProcess(job, jobExecutionContext, bucket);
+
+        rr.commit();
+        List<String> success = bucket.getSuccess();
+        assertEquals(1, success.size(), "Success list size");
+        assertTrue(success.contains("/content/forms/af/sourcefolder/initialform"), "Success item");
+
+        List<String> notFound = bucket.getNotFound();
+        assertEquals(1, notFound.size(), "Not found list size");
+        assertTrue(notFound.contains("/content/forms/af/not-found-form"), "Not found item");
+
+        Node page = rr.getResource("/content/forms/af/sourcefolder/initialform").adaptTo(Node.class);
+        NodeIterator pageNodes = page.getNodes();
+        assertEquals(NameConstants.NN_CONTENT, pageNodes.nextNode().getName(), "Content order");
+
+        ValueMap vm = rr.getResource("/content/forms/af/sourcefolder/initialform/jcr:content").adaptTo(ValueMap.class);
+        assertEquals(version, vm.get(PN_PRE_MODERNIZE_VERSION, String.class));
+
+        vm = rr.getResource("/content/forms/af/sourcefolder/initialform/jcr:content/guideContainer/rootPanel/items/guidetextbox")
+                .adaptTo(ValueMap.class);
+        assertNull(vm.get("mandatory"), "Temp property removed");
+        assertEquals(true, vm.get("required", Boolean.class));
+        assertEquals("text-input", vm.get("fieldType", String.class));
+        assertEquals("aem-modernize/components/form/textinput",
+                vm.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class), "Text Input Sling Resource Type");
+
+        Node formDamAssetNode = rr.getResource("/content/dam/formsanddocuments/targetfolder").adaptTo(Node.class);
+        assertTrue(formDamAssetNode.hasNode("initialform"));
+        vm = rr.getResource("/content/dam/formsanddocuments/targetfolder/initialform/jcr:content/metadata").adaptTo(ValueMap.class);
+        assertEquals("testFormConversion", vm.get("title"));
+    }
+
+    @Test
+    public <P extends PageManager> void doProcessReprocess() throws Exception {
+        final String path = ConversionJob.JOB_DATA_LOCATION + "/form/reprocess/buckets/bucket0";
+        ResourceResolver rr = context.resourceResolver();
+
+        new MockUp<P>() {
+            @Mock
+            public Revision createRevision(Page page, String label, String desc) {
+                assertNotNull(page);
+                assertNotNull(label);
+                assertNotNull(desc);
+                return revision;
+            }
+
+            @Mock
+            public Page restore(String path, String id) throws RepositoryException {
+                Node node = rr.getResource(path + "/jcr:content").adaptTo(Node.class);
+                if (node.hasProperty(PN_PRE_MODERNIZE_VERSION)) {
+                    node.getProperty(PN_PRE_MODERNIZE_VERSION).remove();
+                }
+                return rr.getResource(path).adaptTo(Page.class);
+            }
+        };
+
+        new Expectations() {{
+            jobExecutionContext.initProgress(pathCount, -1);
+            revision.getId();
+            result = version;
+            jobExecutionContext.incrementProgressCount(1);
+            times = pathCount;
+        }};
+
+        ConversionJobBucket bucket = rr.getResource(path).adaptTo(ConversionJobBucket.class);
+        executor.doProcess(job, jobExecutionContext, bucket);
+
+        rr.commit();
+        List<String> success = bucket.getSuccess();
+        assertEquals(1, success.size(), "Success list size");
+        assertTrue(success.contains("/content/forms/af/sourcefolder/initialform"), "Success item");
+
+        List<String> notFound = bucket.getNotFound();
+        assertEquals(1, notFound.size(), "Not found list size");
+        assertTrue(notFound.contains("/content/forms/af/not-found-form"), "Not found item");
+
+        Node page = rr.getResource("/content/forms/af/sourcefolder/initialform").adaptTo(Node.class);
+        NodeIterator pageNodes = page.getNodes();
+        assertEquals(NameConstants.NN_CONTENT, pageNodes.nextNode().getName(), "Content order");
+
+        ValueMap vm = rr.getResource("/content/forms/af/sourcefolder/initialform/jcr:content").adaptTo(ValueMap.class);
+        assertEquals(version, vm.get(PN_PRE_MODERNIZE_VERSION, String.class));
+
+        vm = rr.getResource("/content/forms/af/sourcefolder/initialform/jcr:content/guideContainer/rootPanel/items/guidetextbox")
+                .adaptTo(ValueMap.class);
+        assertNull(vm.get("mandatory"), "Temp property removed");
+        assertEquals(true, vm.get("required", Boolean.class));
+        assertEquals("text-input", vm.get("fieldType", String.class));
+        assertEquals("aem-modernize/components/form/textinput",
+                vm.get(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, String.class), "Text Input Sling Resource Type");
+    }
+}

--- a/core/src/test/java/com/adobe/aem/modernize/job/FormConversionJobExecutorTest.java
+++ b/core/src/test/java/com/adobe/aem/modernize/job/FormConversionJobExecutorTest.java
@@ -77,6 +77,26 @@ public class FormConversionJobExecutorTest {
     }
 
     @Test
+    public void testSourceRootMissing() throws RepositoryException {
+        final String path = ConversionJob.JOB_DATA_LOCATION + "/form/noReprocess/buckets/bucket0";
+        new Expectations() {{
+            jobExecutionContext.initProgress(pathCount, -1);
+        }};
+        ResourceResolver rr = context.resourceResolver();
+        Node n = rr.getResource(ConversionJob.JOB_DATA_LOCATION + "/form/noReprocess").adaptTo(Node.class);
+        n.setProperty("sourceRoot", "");
+        ConversionJobBucket bucket = rr.getResource(path).adaptTo(ConversionJobBucket.class);
+        executor.doProcess(job, jobExecutionContext, bucket);
+        List<String> failed = bucket.getFailed();
+        assertEquals(1, failed.size(), "Failed list size");
+        assertTrue(failed.contains("/content/forms/af/sourcefolder/initialform"), "Failed item");
+
+        List<String> notFound = bucket.getNotFound();
+        assertEquals(1, notFound.size(), "Not found list size");
+        assertTrue(notFound.contains("/content/forms/af/not-found-form"), "Not found item");
+    }
+
+    @Test
     public <P extends PageManager> void createVersionManagementFails() {
         final String path = ConversionJob.JOB_DATA_LOCATION + "/form/noReprocess/buckets/bucket0";
         ResourceResolver rr = context.resourceResolver();

--- a/core/src/test/resources/job/form-job-data.json
+++ b/core/src/test/resources/job/form-job-data.json
@@ -1,0 +1,44 @@
+{
+  "noReprocess": {
+    "jcr:primaryType": "nt:unstructured",
+    "jcr:title": "testformconversionjob",
+    "type": "FORM",
+    "pageHandling": "COPY",
+    "sourceRoot": "/content/forms/af/sourcefolder",
+    "targetRoot": "/content/forms/af/targetfolder",
+    "componentRules": [
+      "/var/aem-modernize/rules/textInput",
+      "/var/aem-modernize/rules/formTitle",
+      "/var/aem-modernize/rules/numberInput",
+      "/var/aem-modernize/rules/emailInput"
+    ],
+    "buckets": {
+      "bucket0": {
+        "paths": [
+          "/content/forms/af/sourcefolder/initialform",
+          "/content/forms/af/not-found-form"
+        ]
+      }
+    }
+  },
+  "reprocess": {
+    "jcr:primaryType": "nt:unstructured",
+    "jcr:title": "testformconversionjob",
+    "type": "FORM",
+    "pageHandling": "RESTORE",
+    "componentRules": [
+      "/var/aem-modernize/rules/textInput",
+      "/var/aem-modernize/rules/formTitle",
+      "/var/aem-modernize/rules/numberInput",
+      "/var/aem-modernize/rules/emailInput"
+    ],
+    "buckets": {
+      "bucket0": {
+        "paths": [
+          "/content/forms/af/sourcefolder/initialform",
+          "/content/forms/af/not-found-form"
+        ]
+      }
+    }
+  }
+}

--- a/core/src/test/resources/job/initial-form-asset-content.json
+++ b/core/src/test/resources/job/initial-form-asset-content.json
@@ -1,0 +1,25 @@
+{
+  "jcr:primaryType":"dam:Asset",
+  "jcr:createdBy":"admin",
+  "jcr:created":"Wed Mar 13 2024 12:02:23 GMT+0530",
+  "jcr:content":{
+    "jcr:primaryType":"dam:AssetContent",
+    "type":"guide",
+    "guide":"1",
+    "cq:conf":"",
+    "jcr:lastModified":"Wed Mar 13 2024 12:04:00 GMT+0530",
+    "sling:resourceType":"fd/fm/af/render",
+    "metadata":{
+      "jcr:primaryType":"nt:unstructured",
+      "author":"admin",
+      "xmp:CreatorTool":"AEM Forms AF Wizard",
+      "jcr:language":"en",
+      "allowedRenderFormat":"HTML",
+      "fd:version":"1.1",
+      "title":"testFormConversion",
+      "themeRef":"/content/dam/formsanddocuments-themes/reference-themes/canvas-3-0",
+      "formmodel":"none",
+      "dorType":"none"
+    }
+  }
+}

--- a/core/src/test/resources/job/initial-form-content.json
+++ b/core/src/test/resources/job/initial-form-content.json
@@ -1,0 +1,115 @@
+{
+  "initialform" : {
+    "jcr:primaryType" : "cq:Page",
+    "jcr:createdBy" : "admin",
+    "jcr:created": "Wed Mar 13 2024 12:02:23 GMT+0530",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "cq:template": "/conf/ReferenceEditableTemplates/settings/wcm/templates/blank",
+      "jcr:createdBy" : "admin",
+      "jcr:created": "Wed Mar 13 2024 12:02:23 GMT+0530",
+      "jcr:language": "en",
+      "jcr:title": "initialform",
+      "sling:resourceType": "fd/af/components/page2/aftemplatedpage",
+      "guideContainer": {
+        "jcr:primaryType": "nt:unstructured",
+        "disableSwipeGesture": false,
+        "guideCss": "guideContainer",
+        "useExistingAF": "false",
+        "fd:version": "1.1",
+        "name": "guide1",
+        "guideNodeClass": "guideContainerNode",
+        "themeRef": "/content/dam/formsanddocuments-themes/reference-themes/canvas-3-0",
+        "sling:resourceType": "fd/af/components/guideContainer",
+        "textIsRich": "true",
+        "dorType": "none",
+        "actionType": "fd/fp/components/actions/portalsubmit",
+        "layout": {
+          "jcr:primaryType": "nt:unstructured",
+          "toolbarPosition": "Bottom",
+          "sling:resourceType": "fd/af/layouts/defaultGuideLayout",
+          "mobileLayout": "fd/af/layouts/mobile/step"
+        },
+        "rootPanel": {
+          "jcr:primaryType": "nt:unstructured",
+          "jcr:title": "Root Panel",
+          "panelSetType": "Navigable",
+          "dorExcludeTitle": "true",
+          "name": "guideRootPanel",
+          "guideNodeClass": "rootPanelNode",
+          "sling:resourceType": "fd/af/components/rootPanel",
+          "dorExcludeDescription": "true",
+          "layout": {
+            "jcr:primaryType": "nt:unstructured",
+            "toolbarPosition": "Bottom",
+            "sling:resourceType": "fd/af/layouts/gridFluidLayout",
+            "nonNavigable": true
+          },
+          "items": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "fd/af/layouts/gridFluidLayout2",
+            "afformtitle": {
+              "_value": "<p>Form Title <\\/p>",
+              "jcr:lastModifiedBy":"admin",
+              "jcr:created":"Wed Mar 13 2024 12:03:29 GMT+0530",
+              "css":"guideformtitle container",
+              "name":"formTitle",
+              "guideNodeClass":"guideTextDraw",
+              "jcr:lastModified":"Wed Mar 13 2024 12:03:29 GMT+0530",
+              "sling:resourceType":"fd/af/components/afFormTitle"
+            },
+            "guidetextbox": {
+              "jcr:primaryType":"nt:unstructured",
+              "jcr:createdBy":"admin",
+              "jcr:title":"Text Box",
+              "jcr:lastModifiedBy":"admin",
+              "jcr:created":"Wed Mar 13 2024 12:03:35 GMT+0530",
+              "name":"textbox1710311616010",
+              "guideNodeClass":"guideTextBox",
+              "mandatory": true,
+              "jcr:lastModified":"Wed Mar 13 2024 12:03:35 GMT+0530",
+              "sling:resourceType":"fd/af/components/guidetextbox"
+            },
+            "guidenumericbox": {
+              "jcr:primaryType":"nt:unstructured",
+              "jcr:createdBy":"admin",
+              "jcr:title":"Numeric Box",
+              "jcr:lastModifiedBy":"admin",
+              "jcr:created":"Wed Mar 13 2024 12:03:43 GMT+0530",
+              "name":"numericbox1710311623385",
+              "guideNodeClass":"guideNumericBox",
+              "jcr:lastModified":"Wed Mar 13 2024 12:03:43 GMT+0530",
+              "sling:resourceType":"fd/af/components/guidenumericbox"
+            },
+            "guideemail": {
+              "jcr:primaryType":"nt:unstructured",
+              "jcr:createdBy":"admin",
+              "jcr:title":"Email",
+              "jcr:lastModifiedBy":"admin",
+              "jcr:created":"Wed Mar 13 2024 12:04:00 GMT+0530",
+              "name":"email1710311640737",
+              "validatePictureClause":"^(([^<>()\\[\\]\\\\.,;:\\s@\"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@\"]+)*)|(\".+\"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$",
+              "guideNodeClass":"guideTextBox",
+              "jcr:lastModified":"Wed Mar 13 2024 12:04:00 GMT+0530",
+              "sling:resourceType":"fd/af/components/guideemail",
+              "autofillFieldKeyword":"email"
+            }
+          }
+        },
+        "autoSaveInfo": {
+          "jcr:primaryType": "nt:unstructured",
+          "metadataselector": "global"
+        },
+        "signerInfo": {
+          "jcr:primaryType": "nt:unstructured",
+          "firstSignerFormFiller": "false",
+          "workflowType": "SEQUENTIAL",
+          "signer0": {
+            "jcr:primaryType": "nt:unstructured",
+            "signerTitle": "Signer One"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/job/test-form-rules.json
+++ b/core/src/test/resources/job/test-form-rules.json
@@ -1,0 +1,80 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "textInput": {
+    "jcr:primaryType":"nt:unstructured",
+    "patterns":{
+      "jcr:primaryType":"nt:unstructured",
+      "textInput":{
+        "jcr:primaryType":"nt:unstructured",
+        "sling:resourceType":"fd/af/components/guidetextbox"
+      }
+    },
+    "replacement":{
+      "jcr:primaryType":"nt:unstructured",
+      "textInput":{
+        "jcr:primaryType":"nt:unstructured",
+        "jcr:title":"${'./jcr:title'}",
+        "sling:resourceType":"aem-modernize/components/form/textinput",
+        "fieldType":"text-input",
+        "required":"${./mandatory}"
+      }
+    }
+  },
+  "formTitle": {
+    "jcr:primaryType":"nt:unstructured",
+    "patterns":{
+      "jcr:primaryType":"nt:unstructured",
+      "formTitle":{
+        "jcr:primaryType":"nt:unstructured",
+        "sling:resourceType":"fd/af/components/afFormTitle"
+      }
+    },
+    "replacement":{
+      "jcr:primaryType":"nt:unstructured",
+      "formTitle":{
+        "jcr:primaryType":"nt:unstructured",
+        "jcr:title":"${'./jcr:title'}",
+        "sling:resourceType":"aem-modernize/components/form/title",
+        "fieldType":"plain-text"
+      }
+    }
+  },
+  "numberInput": {
+    "jcr:primaryType":"nt:unstructured",
+    "patterns":{
+      "jcr:primaryType":"nt:unstructured",
+      "numberInput":{
+        "jcr:primaryType":"nt:unstructured",
+        "sling:resourceType":"fd/af/components/guidenumericbox"
+      }
+    },
+    "replacement":{
+      "jcr:primaryType":"nt:unstructured",
+      "numberInput":{
+        "jcr:primaryType":"nt:unstructured",
+        "jcr:title":"${'./jcr:title'}",
+        "sling:resourceType":"aem-modernize/components/form/numberinput",
+        "fieldType":"number-input"
+      }
+    }
+  },
+  "emailInput": {
+    "jcr:primaryType":"nt:unstructured",
+    "patterns":{
+      "jcr:primaryType":"nt:unstructured",
+      "emailInput":{
+        "jcr:primaryType":"nt:unstructured",
+        "sling:resourceType":"fd/af/components/guideemail"
+      }
+    },
+    "replacement":{
+      "jcr:primaryType":"nt:unstructured",
+      "emailInput":{
+        "jcr:primaryType":"nt:unstructured",
+        "jcr:title":"${'./jcr:title'}",
+        "sling:resourceType":"aem-modernize/components/form/emailinput",
+        "fieldType":"email"
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.adobe.aem</groupId>
     <artifactId>aem-modernize-tools</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <name>AEM Modernize Tools</name>
     <description>AEM Modernize Tools</description>
     <url>https://opensource.adobe.com/aem-modernize-tools/</url>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.adobe.aem</groupId>
         <artifactId>aem-modernize-tools</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,7 @@
                         <filter><root>/apps</root></filter>
                         <filter><root>/apps/aem-modernize</root></filter>
                         <filter><root>/apps/aem-modernize/content</root></filter>
-                        
+
                         <filter><root>/apps/aem-modernize-packages</root></filter>
 
                         <filter><root>/apps/cq</root></filter>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem</groupId>
         <artifactId>aem-modernize-tools</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/.content.xml
@@ -3,14 +3,14 @@
   #%L
   AEM Modernize Tools - UI apps
   %%
-  Copyright (C) 2019 - 2021 Adobe Inc.
+  Copyright (C) 2019 - 2024 Adobe Inc.
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/.content.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  AEM Modernize Tools - UI apps
+  %%
+  Copyright (C) 2019 - 2021 Adobe Inc.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+          jcr:primaryType="nt:unstructured">
+
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/.content.xml
@@ -3,14 +3,14 @@
   #%L
   AEM Modernize Tools - UI apps
   %%
-  Copyright (C) 2019 - 2021 Adobe Inc.
+  Copyright (C) 2019 - 2024 Adobe Inc.
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/.content.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  AEM Modernize Tools - UI apps
+  %%
+  Copyright (C) 2019 - 2021 Adobe Inc.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+          jcr:primaryType="nt:unstructured">
+
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/.content.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  AEM Modernize Tools - UI apps
+  %%
+  Copyright (C) 2019 - 2021 Adobe Inc.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:ClientLibraryFolder"
+          categories="[aem.modernize.job.form]"
+          dependencies="[coralui3,granite.ui.coral.foundation,aem.modernize.job.common]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/.content.xml
@@ -3,7 +3,7 @@
   #%L
   AEM Modernize Tools - UI apps
   %%
-  Copyright (C) 2019 - 2021 Adobe Inc.
+  Copyright (C) 2019 - 2024 Adobe Inc.
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+create.js

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/js/create.js
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/js/create.js
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * AEM Modernize Tools - UI apps
+ * %%
+ * Copyright (C) 2019 - 2021 Adobe Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+(function(document, AemModernize) {
+  "use strict";
+
+  let form;
+
+  class CreateConvertFormJobForm extends AemModernize.CreateJobForm {
+  }
+
+  $(function() {
+    form = new CreateConvertFormJobForm();
+  });
+
+})(document, AemModernize);

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/js/create.js
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/clientlib/js/create.js
@@ -2,7 +2,7 @@
  * #%L
  * AEM Modernize Tools - UI apps
  * %%
- * Copyright (C) 2019 - 2021 Adobe Inc.
+ * Copyright (C) 2019 - 2024 Adobe Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/create/.content.xml
@@ -1,0 +1,303 @@
+<!--
+  #%L
+  AEM Modernize Tools - UI apps
+  %%
+  Copyright (C) 2019 - 2021 Adobe Inc.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+          xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:title="AEM Modernize Tools | Form Page Conversion"
+          jcr:primaryType="nt:unstructured"
+          sling:resourceType="aem-modernize/content/job/create"
+          cq:defaultView="html"
+          consoleId="cq-modernize-job-adaptive-form">
+  <head jcr:primaryType="nt:unstructured">
+    <clientlibs
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"
+        categories="[granite.shared,coralui3,granite.ui.coral.foundation,granite.ui.coral.foundation.admin,aem.modernize.job.common,aem.modernize.job.form]"/>
+  </head>
+  <body jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/page/body">
+    <items jcr:primaryType="nt:unstructured">
+      <form jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/form"
+            granite:class="aem-modernize-job-form aem-modernize-structure-job-form"
+            maximized="{Boolean}true"
+            method="post"
+            novalidate="true"
+            style="aligned">
+        <granite:data jcr:primaryType="nt:unstructured"
+                      aem-modernize-url="${granite:url('/mnt/overlay/aem-modernize/content/form/job/create.json')}"
+                      aem-modernize-job-view-url="${granite:url('/mnt/overlay/aem-modernize/content/form/job/view.html')}"
+                      aem-modernize-components="true"
+                      aem-modernize-operation="FORM"/>
+        <items jcr:primaryType="nt:unstructured">
+          <wizard jcr:primaryType="nt:unstructured"
+                  cancelHref="${empty header.Referer ? &quot;/aem/start.html&quot; : header.Referer}"
+                  jcr:title="Convert Form Content"
+                  sling:resourceType="granite/ui/components/coral/foundation/wizard"
+                  granite:class="aem-modernize-job-wizard aem-modernize-form-job-wizard"
+                  trackingFeature="aem:modernize:convert:form">
+            <items jcr:primaryType="nt:unstructured">
+              <details jcr:primaryType="nt:unstructured"
+                       jcr:title="Job Details"
+                       sling:resourceType="granite/ui/components/coral/foundation/container">
+                <parentConfig jcr:primaryType="nt:unstructured">
+                  <next jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/button"
+                        granite:class="foundation-wizard-control"
+                        disabled="{Boolean}true"
+                        variant="primary"
+                        text="Next">
+                    <granite:data jcr:primaryType="nt:unstructured"
+                                  foundation-wizard-control-action="next"/>
+                  </next>
+                </parentConfig>
+                <items jcr:primaryType="nt:unstructured">
+                  <fixedColumnContainer jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                        margin="{Boolean}true"
+                                        maximized="{Boolean}true">
+                    <items jcr:primaryType="nt:unstructured">
+                      <fixedColumn jcr:primaryType="nt:unstructured"
+                                   sling:resourceType="granite/ui/components/coral/foundation/container"
+                                   margin="{Boolean}true"
+                                   maximized="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                          <general jcr:primaryType="nt:unstructured"
+                                  jcr:title="General"
+                                  sling:resourceType="granite/ui/components/coral/foundation/form/fieldset"
+                                  margin="{Boolean}true"
+                                  maximized="{Boolean}true">
+                            <items jcr:primaryType="nt:unstructured">
+                              <name jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                    name="name"
+                                    fieldLabel="Job Name"
+                                    required="{Boolean}true"/>
+                            </items>
+                          </general>
+                          <formConfig jcr:primaryType="nt:unstructured"
+                                      jcr:title="Form"
+                                      sling:resourceType="granite/ui/components/coral/foundation/form/fieldset"
+                                      margin="{Boolean}true"
+                                      maximized="{Boolean}true">
+                            <items jcr:primaryType="nt:unstructured">
+                              <formHandling jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/radiogroup"
+                                            granite:class="aem-modernize-page-handling"
+                                            fieldLabel="Form Handling"
+                                            name="pageHandling"
+                                            required="{Boolean}true"
+                                            vertical="{Boolean}false" >
+                                <items jcr:primaryType="nt:unstructured">
+                                  <none jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                        value="NONE"
+                                        text="None"
+                                        checked="{Boolean}true"/>
+                                  <restore jcr:primaryType="nt:unstructured"
+                                           sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                           value="RESTORE"
+                                           text="Restore"
+                                           fieldDescription="Select this to restore form to state before last Structure conversion."/>
+                                  <copy jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
+                                        value="COPY"
+                                        text="Copy to Target"
+                                        fieldDescription="Select this option to copy the form before processing." />
+                                </items>
+                              </formHandling>
+                              <sourceRoot jcr:primaryType="nt:unstructured"
+                                          sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                          granite:rel="aem-modernize-job-source-root"
+                                          fieldLabel="Source Path"
+                                          fieldDescription="Each form will have this portion of the path replaced with the target location."
+                                          required="{Boolean}false"
+                                          multiple="{Boolean}false"
+                                          name="sourceRoot"
+                                          rootPath="/content/forms/af"
+                                          filter="hierarchyNotFile"
+                                          disabled="{Boolean}true">
+                              </sourceRoot>
+                              <targetRoot jcr:primaryType="nt:unstructured"
+                                          sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                          fieldLabel="Target Path"
+                                          required="{Boolean}false"
+                                          multiple="{Boolean}false"
+                                          name="targetRoot"
+                                          rootPath="/content/forms/af"
+                                          filter="hierarchyNotFile"
+                                          disabled="{Boolean}true"/>
+                            </items>
+                          </formConfig>
+                          <!-- <policyConfig jcr:primaryType="nt:unstructured"
+                                        jcr:title="Policy"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset"
+                                        margin="{Boolean}true"
+                                        maximized="{Boolean}true">
+                            <items jcr:primaryType="nt:unstructured">
+                              <confPath jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="cq/cloudconfig/components/admin/configpathbrowser"
+                                        activeSelectionCount="single"
+                                        name="confPath"
+                                        fieldLabel="Configuration Path"
+                                        fieldDescription="Select the Configuration path for the Policy Import process."
+                                        required="{Boolean}true" />
+                              <includeSuper jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                            checked="{Boolean}true"
+                                            name="includeSuperTypes"
+                                            value="true"
+                                            uncheckedValue="false"
+                                            text="Include Super Types?"
+                                            disabled="true"
+                                            fieldDescription="This is automatically set for full page conversion."/>
+                              <overwrite jcr:primaryType="nt:unstructured"
+                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                         checked="{Boolean}false"
+                                         name="overwrite"
+                                         value="{Boolean}true"
+                                         text="Overwrite Existing?"
+                                         fieldDescription="Select this to reimport designs already converted to policies."/>
+                            </items>
+                          </policyConfig> -->
+                        </items>
+                      </fixedColumn>
+                    </items>
+                  </fixedColumnContainer>
+                </items>
+              </details>
+              <scope jcr:primaryType="nt:unstructured"
+                     jcr:title="Form Selection"
+                     sling:resourceType="granite/ui/components/coral/foundation/container"
+                     maximized="{Boolean}true">
+                <parentConfig jcr:primaryType="nt:unstructured">
+                  <next jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/button"
+                        granite:class="foundation-wizard-control aem-modernize-job-create-next"
+                        disabled="{Boolean}true"
+                        variant="primary"
+                        type="submit"
+                        text="Schedule Job"
+                        trackingElement="schedule job"
+                        trackingFeature="aem:modernize:job:form:schedule">
+                    <granite:data jcr:primaryType="nt:unstructured"
+                                  foundation-wizard-control-action="next"/>
+                  </next>
+                </parentConfig>
+                <items jcr:primaryType="nt:unstructured">
+                  <default jcr:primaryType="nt:unstructured"
+                           sling:resourceType="granite/ui/components/coral/foundation/actionbar">
+                    <primary jcr:primaryType="nt:unstructured">
+                      <add jcr:primaryType="nt:unstructured"
+                           sling:resourceType="granite/ui/components/coral/foundation/button"
+                           granite:class="foundation-collection-action foundation-picker-control aem-modernize-job-add-pages"
+                           icon="add"
+                           text="Add Forms"
+                           variant="actionBar">
+                        <granite:data jcr:primaryType="nt:unstructured"
+                                      foundation-collection-action="\{&quot;target&quot;:&quot;.aem-modernize-job-pages&quot;,&quot;activeSelectionCount&quot;:&quot;none&quot;,&quot;relScope&quot;:&quot;collection&quot;}"
+                                      foundation-picker-control-action="\{&quot;name&quot;:&quot;aem.modernize.addcontent&quot;,&quot;data&quot;:{}}"
+                                      foundation-picker-control-src="/mnt/overlay/granite/ui/content/coral/foundation/form/pathfield/picker.html?root=%2Fcontent%2Fforms%2Faf&amp;filter=hierarchyNotFile&amp;selectionCount=multiple"/>
+                      </add>
+                      <!-- <includechildren jcr:primaryType="nt:unstructured"
+                                       sling:resourceType="granite/ui/components/coral/foundation/button"
+                                       granite:class="foundation-collection-action aem-modernize-collection-action-includechildren"
+                                       icon="add"
+                                       text="Include Children"
+                                       variant="actionBar">
+                        <granite:data jcr:primaryType="nt:unstructured"
+                                      foundation-collection-action="\{&quot;target&quot;:&quot;.aem-modernize-job-pages&quot;,&quot;activeSelectionCount&quot;:&quot;single&quot;,&quot;action&quot;:&quot;foundation.dialog&quot;,&quot;data&quot;:{&quot;src&quot;:&quot;/mnt/overlay/aem-modernize/content/job/dialog/includechildren.html{+item}&quot;},&quot;relScope&quot;:&quot;collection&quot;}"/>
+                      </includechildren> -->
+                      <remove jcr:primaryType="nt:unstructured"
+                              sling:resourceType="granite/ui/components/coral/foundation/button"
+                              granite:class="foundation-collection-action aem-modernize-collection-action-delete"
+                              icon="delete"
+                              text="Remove Selection"
+                              variant="actionBar">
+                        <granite:data jcr:primaryType="nt:unstructured"
+                                      foundation-collection-action="\{&quot;target&quot;:&quot;.aem-modernize-job-pages&quot;,&quot;activeSelectionCount&quot;:&quot;multiple&quot;,&quot;relScope&quot;:&quot;collection&quot;}"/>
+                      </remove>
+                    </primary>
+                    <secondary jcr:primaryType="nt:unstructured">
+                      <collectionstatus jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="aem-modernize/components/job/create/status"
+                                        targetCollection=".aem-modernize-job-pages"/>
+                    </secondary>
+                  </default>
+                  <list jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/table"
+                        granite:rel="aem-modernize-form-job-create aem-modernize-job-pages"
+                        modeGroup="aem-modernize-form-job-create"
+                        selectionCount="multiple"
+                        selectionMode="row"
+                        variant="list"
+                        layoutId="table"
+                        skipEmptyRow="{Boolean}true">
+                    <granite:data jcr:primaryType="nt:unstructured"
+                                  empty-table-column-span="4"/>
+                    <columns jcr:primaryType="nt:unstructured">
+                      <select jcr:primaryType="nt:unstructured"
+                              alignment="center"
+                              fixedWidth="{Boolean}true"
+                              select="{Boolean}true"/>
+                      <path jcr:primaryType="nt:unstructured"
+                            jcr:title="Page"
+                            sortable="{Boolean}true"/>
+                      <!--<stuctureRules jcr:primaryType="nt:unstructured"
+                             jcr:title="Structure Rules"
+                             sortable="{Boolean}false"
+                             alignment="center"
+                             fixedWidth="{Boolean}true"/>
+                      <policies jcr:primaryType="nt:unstructured"
+                                jcr:title="Policies"
+                                sortable="{Boolean}false"
+                                alignment="center"
+                                fixedWidth="{Boolean}true"/>
+                      <policyRules jcr:primaryType="nt:unstructured"
+                             jcr:title="Policy Rules"
+                             sortable="{Boolean}false"
+                             alignment="center"
+                             fixedWidth="{Boolean}true"/> -->
+                      <components jcr:primaryType="nt:unstructured"
+                                  jcr:title="Component Count"
+                                  sortable="{Boolean}false"
+                                  alignment="center"
+                                  fixedWidth="{Boolean}true"/>
+                      <rules jcr:primaryType="nt:unstructured"
+                             jcr:title="Rule Count"
+                             sortable="{Boolean}false"
+                             alignment="center"
+                             fixedWidth="{Boolean}true"/>
+<!--                      <details jcr:primaryType="nt:unstructured"-->
+<!--                               jcr:title="Details"-->
+<!--                               alignment="center"-->
+<!--                               fixedWidth="{Boolean}true"-->
+<!--                               sortable="{Boolean}false"/>-->
+                    </columns>
+                  </list>
+                </items>
+              </scope>
+            </items>
+          </wizard>
+        </items>
+      </form>
+    </items>
+  </body>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/create/.content.xml
@@ -2,7 +2,7 @@
   #%L
   AEM Modernize Tools - UI apps
   %%
-  Copyright (C) 2019 - 2021 Adobe Inc.
+  Copyright (C) 2019 - 2024 Adobe Inc.
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -146,37 +146,6 @@
                                           disabled="{Boolean}true"/>
                             </items>
                           </formConfig>
-                          <!-- <policyConfig jcr:primaryType="nt:unstructured"
-                                        jcr:title="Policy"
-                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset"
-                                        margin="{Boolean}true"
-                                        maximized="{Boolean}true">
-                            <items jcr:primaryType="nt:unstructured">
-                              <confPath jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="cq/cloudconfig/components/admin/configpathbrowser"
-                                        activeSelectionCount="single"
-                                        name="confPath"
-                                        fieldLabel="Configuration Path"
-                                        fieldDescription="Select the Configuration path for the Policy Import process."
-                                        required="{Boolean}true" />
-                              <includeSuper jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                            checked="{Boolean}true"
-                                            name="includeSuperTypes"
-                                            value="true"
-                                            uncheckedValue="false"
-                                            text="Include Super Types?"
-                                            disabled="true"
-                                            fieldDescription="This is automatically set for full page conversion."/>
-                              <overwrite jcr:primaryType="nt:unstructured"
-                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                         checked="{Boolean}false"
-                                         name="overwrite"
-                                         value="{Boolean}true"
-                                         text="Overwrite Existing?"
-                                         fieldDescription="Select this to reimport designs already converted to policies."/>
-                            </items>
-                          </policyConfig> -->
                         </items>
                       </fixedColumn>
                     </items>
@@ -216,15 +185,6 @@
                                       foundation-picker-control-action="\{&quot;name&quot;:&quot;aem.modernize.addcontent&quot;,&quot;data&quot;:{}}"
                                       foundation-picker-control-src="/mnt/overlay/granite/ui/content/coral/foundation/form/pathfield/picker.html?root=%2Fcontent%2Fforms%2Faf&amp;filter=hierarchyNotFile&amp;selectionCount=multiple"/>
                       </add>
-                      <!-- <includechildren jcr:primaryType="nt:unstructured"
-                                       sling:resourceType="granite/ui/components/coral/foundation/button"
-                                       granite:class="foundation-collection-action aem-modernize-collection-action-includechildren"
-                                       icon="add"
-                                       text="Include Children"
-                                       variant="actionBar">
-                        <granite:data jcr:primaryType="nt:unstructured"
-                                      foundation-collection-action="\{&quot;target&quot;:&quot;.aem-modernize-job-pages&quot;,&quot;activeSelectionCount&quot;:&quot;single&quot;,&quot;action&quot;:&quot;foundation.dialog&quot;,&quot;data&quot;:{&quot;src&quot;:&quot;/mnt/overlay/aem-modernize/content/job/dialog/includechildren.html{+item}&quot;},&quot;relScope&quot;:&quot;collection&quot;}"/>
-                      </includechildren> -->
                       <remove jcr:primaryType="nt:unstructured"
                               sling:resourceType="granite/ui/components/coral/foundation/button"
                               granite:class="foundation-collection-action aem-modernize-collection-action-delete"
@@ -260,21 +220,6 @@
                       <path jcr:primaryType="nt:unstructured"
                             jcr:title="Page"
                             sortable="{Boolean}true"/>
-                      <!--<stuctureRules jcr:primaryType="nt:unstructured"
-                             jcr:title="Structure Rules"
-                             sortable="{Boolean}false"
-                             alignment="center"
-                             fixedWidth="{Boolean}true"/>
-                      <policies jcr:primaryType="nt:unstructured"
-                                jcr:title="Policies"
-                                sortable="{Boolean}false"
-                                alignment="center"
-                                fixedWidth="{Boolean}true"/>
-                      <policyRules jcr:primaryType="nt:unstructured"
-                             jcr:title="Policy Rules"
-                             sortable="{Boolean}false"
-                             alignment="center"
-                             fixedWidth="{Boolean}true"/> -->
                       <components jcr:primaryType="nt:unstructured"
                                   jcr:title="Component Count"
                                   sortable="{Boolean}false"
@@ -285,11 +230,6 @@
                              sortable="{Boolean}false"
                              alignment="center"
                              fixedWidth="{Boolean}true"/>
-<!--                      <details jcr:primaryType="nt:unstructured"-->
-<!--                               jcr:title="Details"-->
-<!--                               alignment="center"-->
-<!--                               fixedWidth="{Boolean}true"-->
-<!--                               sortable="{Boolean}false"/>-->
                     </columns>
                   </list>
                 </items>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/list/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/list/.content.xml
@@ -23,7 +23,7 @@
           xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
           xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
           jcr:primaryType="nt:unstructured"
-          jcr:title="AEM Modernize Tools | Form Conversion Jobs"
+          jcr:title="AEM Modernize Tools | Adaptive Form Conversion Jobs"
           sling:resourceType="granite/ui/components/shell/collectionpage"
           cq:defaultView="html"
           consoleId="cq-modernize-job-form-list"
@@ -48,7 +48,7 @@
     </secondary>
   </actions>
   <title jcr:primaryType="nt:unstructured"
-         text="Form Conversion Jobs"
+         text="Adaptive Form Conversion Jobs"
          sling:resourceType="granite/ui/components/coral/foundation/text"/>
   <views jcr:primaryType="nt:unstructured">
     <card jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/list/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/list/.content.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  AEM Modernize Tools - UI apps
+  %%
+  Copyright (C) 2019 - 2021 Adobe Inc.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="AEM Modernize Tools | Form Conversion Jobs"
+          sling:resourceType="granite/ui/components/shell/collectionpage"
+          cq:defaultView="html"
+          consoleId="cq-modernize-job-form-list"
+          modeGroup="aem-modernize-job-collection"
+          currentView="${state[&quot;shell.collectionpage.layoutId&quot;].string}"
+          targetCollection=".aem-modernize-job-collection">
+  <head jcr:primaryType="nt:unstructured">
+    <clientlibs
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"
+        categories="[granite.shared,coralui3,granite.ui.coral.foundation,granite.ui.coral.foundation.admin,aem.modernize.job.common]"/>
+  </head>
+  <actions jcr:primaryType="nt:unstructured">
+    <secondary jcr:primaryType="nt:unstructured">
+      <create jcr:primaryType="nt:unstructured"
+              sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
+              href="/mnt/overlay/aem-modernize/content/form/job/create.html"
+              text="Create"
+              variant="primary"
+              trackingElement="create job"
+              trackingFeature="aem:modernize:job:form:create"/>
+    </secondary>
+  </actions>
+  <title jcr:primaryType="nt:unstructured"
+         text="Form Conversion Jobs"
+         sling:resourceType="granite/ui/components/coral/foundation/text"/>
+  <views jcr:primaryType="nt:unstructured">
+    <card jcr:primaryType="nt:unstructured"
+          jcr:title="Card View"
+          sling:resourceType="granite/ui/components/coral/foundation/masonry"
+          granite:rel="aem-modernize-job-collection"
+          selectionCount="single"
+          selectionMode="none"
+          icon="viewCard"
+          layoutId="card"
+          modeGroup="aem-modernize-job-collection"
+          path="/var/aem-modernize/job-data/form"
+          src="/apps/aem-modernize/content/form/job/list/views/card{.offset,limit}.html"
+          detailViewUrl="/mnt/overlay/aem-modernize/content/form/job/view.html"
+          itemResourceType="aem-modernize/components/job/card"
+          stateId="shell.collectionpage"
+          limit="{Long}20">
+      <datasource jcr:primaryType="nt:unstructured"
+                  limit="${empty requestPathInfo.selectors[1] ? &quot;21&quot; : requestPathInfo.selectors[1]}"
+                  offset="${requestPathInfo.selectors[0]}"
+                  sling:resourceType="aem-modernize/components/job/datasource"/>
+    </card>
+    <list jcr:primaryType="nt:unstructured"
+          jcr:title="List View"
+          sling:resourceType="granite/ui/components/coral/foundation/table"
+          granite:rel="aem-modernize-job-collection"
+          selectionCount="single"
+          selectionMode="none"
+          draggable="{Boolean}false"
+          icon="viewList"
+          layoutId="list"
+          modeGroup="aem-modernize-job-collection"
+          path="/var/aem-modernize/job-data/form"
+          src="/apps/aem-modernize/content/form/job/list/views/list{.offset,limit}.html"
+          detailViewUrl="/mnt/overlay/aem-modernize/content/form/job/view.html"
+          itemResourceType="aem-modernize/components/job/listitem"
+          stateId="shell.collectionpage"
+          sortMode="local"
+          limit="{Long}40">
+      <datasource jcr:primaryType="nt:unstructured"
+                  limit="${empty requestPathInfo.selectors[1] ? &quot;41&quot; : requestPathInfo.selectors[1]}"
+                  offset="${requestPathInfo.selectors[0]}"
+                  sling:resourceType="aem-modernize/components/job/datasource"/>
+      <columns jcr:primaryType="nt:unstructured">
+        <name jcr:primaryType="nt:unstructured"
+              jcr:title="Name"
+              sortType="alphanumeric"
+              sortable="{Boolean}true"/>
+        <status jcr:primaryType="nt:unstructured"
+                jcr:title="Job Status"
+                sortType="number"
+                sortable="{Boolean}true"/>
+        <date jcr:primaryType="nt:unstructured"
+              jcr:title="Execution Date"
+              sortType="date"
+              alignment="center"
+              sortable="{Boolean}true"/>
+        <multi jcr:primaryType="nt:unstructured"
+               jcr:title="Multi-Bucket"
+               alignment="right"
+               fixedWidth="{Boolean}true"
+               sortable="{Boolean}false"/>
+      </columns>
+    </list>
+  </views>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/list/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/list/.content.xml
@@ -3,7 +3,7 @@
   #%L
   AEM Modernize Tools - UI apps
   %%
-  Copyright (C) 2019 - 2021 Adobe Inc.
+  Copyright (C) 2019 - 2024 Adobe Inc.
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/view/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/view/.content.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  AEM Modernize Tools - UI apps
+  %%
+  Copyright (C) 2019 - 2021 Adobe Inc.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="AEM Modernize Tools | Form Conversion Job Detail"
+          sling:resourceType="granite/ui/components/shell/collectionpage"
+          cq:defaultView="html"
+          consoleId="cq-modernize-job-form-detail"
+          modeGroup="aem-modernize-job-collection"
+          targetCollection=".aem-modernize-job-bucket-collection">
+  <head jcr:primaryType="nt:unstructured">
+    <clientlibs
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"
+        categories="[granite.shared,coralui3,granite.ui.coral.foundation,granite.ui.coral.foundation.admin,aem.modernize.job.common]"/>
+  </head>
+  <title jcr:primaryType="nt:unstructured"
+         text="Form Conversion Job Details"
+         sling:resourceType="aem-modernize/components/job/title"/>
+  <rails jcr:primaryType="nt:unstructured">
+    <navigation jcr:primaryType="nt:unstructured"
+                jcr:title="Job (Bucket) List"
+                sling:resourceType="granite/ui/components/coral/foundation/panel/railpanel"
+                granite:class="cq-rail-navigation"
+                granite:id="aem-modernization-job-navigation"
+                active="{Boolean}true">
+      <items jcr:primaryType="nt:unstructured">
+        <navpanel jcr:primaryType="nt:unstructured"
+                  sling:resourceType="aem-modernize/components/job/view/navpanel"
+                  viewUrl="/mnt/overlay/aem-modernize/content/form/job/view.html"
+                  id="aem-modernize-job-view-navigation-panel"
+                  orientation="vertical"
+                  size="L">
+        </navpanel>
+      </items>
+    </navigation>
+  </rails>
+  <actions jcr:primaryType="nt:unstructured">
+    <secondary jcr:primaryType="nt:unstructured">
+      <return jcr:primaryType="nt:unstructured"
+              sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
+              href="${granite:url('/mnt/overlay/aem-modernize/content/form/job/list.html')}"
+              text="Return to List"
+              variant="quiet"/>
+    </secondary>
+  </actions>
+  <views jcr:primaryType="nt:unstructured">
+    <list jcr:primaryType="nt:unstructured"
+          jcr:title="List View"
+          sling:resourceType="granite/ui/components/coral/foundation/table"
+          granite:rel="aem-modernize-job-bucket-collection"
+          draggable="{Boolean}false"
+          icon="viewList"
+          layoutId="list"
+          modeGroup="aem-modernize-job-bucket-collection"
+          selectionMode="none"
+          selectionCount="single"
+          path="${requestPathInfo.suffix}"
+          bucket="${empty param.bucket ? &quot;0&quot; : param.bucket}"
+          src="${requestPathInfo.resourcePath}{.offset,limit}.html${requestPathInfo.suffix}?${querystring}"
+          itemResourceType="aem-modernize/components/job/bucket/item"
+          sortMode="local"
+          limit="{Long}50">
+      <datasource jcr:primaryType="nt:unstructured"
+                  limit="${empty requestPathInfo.selectors[1] ? &quot;51&quot; : requestPathInfo.selectors[1]}"
+                  offset="${requestPathInfo.selectors[0]}"
+                  sling:resourceType="aem-modernize/components/job/bucket/datasource"/>
+      <columns jcr:primaryType="nt:unstructured">
+        <path jcr:primaryType="nt:unstructured"
+              jcr:title="Path"
+              sortType="alphanumeric"
+              sortable="{Boolean}true"/>
+        <status jcr:primaryType="nt:unstructured"
+                jcr:title="Status"
+                sortType="alphanumeric"
+                sortable="{Boolean}true"/>
+        <icon jcr:primaryType="nt:unstructured"
+              alignment="center"
+              fixedWidth="{Boolean}true"
+              sortable="{Boolean}false"/>
+
+      </columns>
+    </list>
+  </views>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/view/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/view/.content.xml
@@ -23,7 +23,7 @@
           xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
           xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
           jcr:primaryType="nt:unstructured"
-          jcr:title="AEM Modernize Tools | Form Conversion Job Detail"
+          jcr:title="AEM Modernize Tools | Adaptive Form Conversion Job Detail"
           sling:resourceType="granite/ui/components/shell/collectionpage"
           cq:defaultView="html"
           consoleId="cq-modernize-job-form-detail"
@@ -36,7 +36,7 @@
         categories="[granite.shared,coralui3,granite.ui.coral.foundation,granite.ui.coral.foundation.admin,aem.modernize.job.common]"/>
   </head>
   <title jcr:primaryType="nt:unstructured"
-         text="Form Conversion Job Details"
+         text="Adaptive Form Conversion Job Details"
          sling:resourceType="aem-modernize/components/job/title"/>
   <rails jcr:primaryType="nt:unstructured">
     <navigation jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/view/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/view/.content.xml
@@ -3,7 +3,7 @@
   #%L
   AEM Modernize Tools - UI apps
   %%
-  Copyright (C) 2019 - 2021 Adobe Inc.
+  Copyright (C) 2019 - 2024 Adobe Inc.
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/aem-modernize/form/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/aem-modernize/form/.content.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  AEM Modernize Tools - UI apps
+  %%
+  Copyright (C) 2019 - 2021 Adobe Inc.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="Forms Conversion"
+          href="/mnt/overlay/aem-modernize/content/form/job/list.html"
+          icon="form"
+          id="aem-modernize-tools-forms"/>

--- a/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/aem-modernize/form/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/aem-modernize/form/.content.xml
@@ -22,7 +22,7 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
           jcr:mixinTypes="[rep:AccessControllable]"
           jcr:primaryType="nt:unstructured"
-          jcr:title="Forms Conversion"
+          jcr:title="Adaptive Forms Conversion"
           href="/mnt/overlay/aem-modernize/content/form/job/list.html"
           icon="form"
           id="aem-modernize-tools-forms"/>

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem</groupId>
         <artifactId>aem-modernize-tools</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added an executor for Form conversion job.
- Form conversion job would support following form handling:
        **None** [applies an in place component conversion]
        **Restore** [Restore form to a state to last structure conversion and then apply component rules]
        **Copy to Target** [Copying forms from Source directory to Target directory and then applying component conversion.]

For "Copy to Target" option, we are also copying dam asset node to target folder specific to forms.

**NOTE**: I had to disable baseline check since a version upgrade was required in ConversionJob model. Will enable it once this is through bumping up the versions as well.

## Related Issue
https://github.com/adobe/aem-modernize-tools/issues/209

## Motivation and Context

Added in the mentioned issue above.

## How Has This Been Tested?

Added UTs for the form conversion executor.

## Screenshots (if appropriate):

https://github.com/adobe/aem-modernize-tools/assets/7971922/0cc895c8-29a5-47ff-81a9-89aacf3184d0


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
