### PR TITLE
Add support to convert column control to responsive node and process responsiveGrid

### DIFF
--- a/core/src/main/java/com/adobe/aem/modernize/component/rule/ColumnControlRewriteRule.java
+++ b/core/src/main/java/com/adobe/aem/modernize/component/rule/ColumnControlRewriteRule.java
@@ -204,7 +204,7 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
 
     do {
       child = siblings.nextNode();
-      if (isColumnNode(child)) {
+      if (isStartNode(child)) {
         child.remove();
         break;
       }
@@ -228,7 +228,7 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
         addResponsive(node, c, newline, offset);
         order.add(node.getName());
         child = siblings.nextNode();
-        if (isColumnNode(child)) {
+        if (isBreakNode(child) || isEndNode(child)) {
           child.remove();
           siblings.nextNode();
         }
@@ -240,9 +240,13 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
     // Move remaining non column content to the end, preserve the order.
     while (siblings.hasNext()) {
       child = siblings.nextNode();
-      if (isColumnNode(child)) {
-        child.remove();
-        continue;
+      if (isStartNode(child)) {
+          // Recursively process the newly found column control
+          processResponsiveGrid(root);
+          continue;
+      } else if (isBreakNode(child) || isEndNode(child)) {
+          child.remove();
+          continue;
       }
       order.add(child.getName());
     }
@@ -305,7 +309,7 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
       columnContents.add(nodeNames);
       while (siblings.hasNext()) {
         Node node = siblings.nextNode();
-        if (StringUtils.equals(columnControlResourceType, node.getProperty(SLING_RESOURCE_TYPE_PROPERTY).getString())) {
+        if (isBreakNode(node) || isEndNode(node)) {
           // Node is now the next column break;
           break;
         }
@@ -316,12 +320,30 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
     return columnContents;
   }
 
-  private boolean isColumnNode(Node node) throws RepositoryException {
-    if (!node.hasProperty(SLING_RESOURCE_TYPE_PROPERTY)) {
-      return false;
+  // Check if the node is a column control node.
+    private boolean isStartNode(Node node) throws RepositoryException {
+        if (!node.hasProperty(SLING_RESOURCE_TYPE_PROPERTY)) {
+            return false;
+        }
+        return StringUtils.equals(columnControlResourceType,
+            node.getProperty(SLING_RESOURCE_TYPE_PROPERTY).getString());
     }
-    return StringUtils.equals(columnControlResourceType, node.getProperty(SLING_RESOURCE_TYPE_PROPERTY).getString());
-  }
+    // Check if the node is a break node of controlType 'break'
+    private boolean isBreakNode(Node node) throws RepositoryException {
+        if (!node.hasProperty(SLING_RESOURCE_TYPE_PROPERTY)) {
+            return false;
+        }
+        return node.hasProperty("controlType")
+            && StringUtils.equals("break", node.getProperty("controlType").getString());
+    }
+    // Check if the node is an end node of controlType 'end'
+    private boolean isEndNode(Node node) throws RepositoryException {
+        if (!node.hasProperty(SLING_RESOURCE_TYPE_PROPERTY)) {
+            return false;
+        }
+        return node.hasProperty("controlType")
+            && StringUtils.equals("end", node.getProperty("controlType").getString());
+    }
 
   private void addResponsive(Node node, int index, boolean isNewline, boolean isOffset) throws RepositoryException {
     Node responsive = node.addNode(NN_RESPONSIVE_CONFIG, NT_UNSTRUCTURED);
@@ -416,8 +438,8 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
       columnControlResourceType = PROP_RESOURCE_TYPE_DEFAULT;
     }
 
-//    String type = config.grid_type();
-    isResponsive = false; // !StringUtils.equals(PROP_CONTAINER_TYPE, type);
+   String type = config.grid_type();
+    isResponsive = !StringUtils.equals(PROP_CONTAINER_TYPE, type);
 
     containerResourceType = config.container_resourceType();
     if (!isResponsive) {
@@ -475,15 +497,15 @@ public class ColumnControlRewriteRule implements ComponentRewriteRule {
     )
     String column_control_resourceType() default PROP_RESOURCE_TYPE_DEFAULT;
 
-//    @AttributeDefinition(
-//        name = "Conversion Type",
-//        description = "Type of structure to convert to: RESPONSIVE will arrange column contents in parent responsive grid. CONTAINER will replace each column with a container.",
-//        options = {
-//            @Option(label = "Responsive", value = PROP_RESPONSIVE_TYPE),
-//            @Option(label = "Container", value = PROP_CONTAINER_TYPE),
-//        }
-//    )
-//    String grid_type() default PROP_RESPONSIVE_TYPE;
+   @AttributeDefinition(
+       name = "Conversion Type",
+       description = "Type of structure to convert to: RESPONSIVE will arrange column contents in parent responsive grid. CONTAINER will replace each column with a container.",
+       options = {
+           @Option(label = "Responsive", value = PROP_RESPONSIVE_TYPE),
+           @Option(label = "Container", value = PROP_CONTAINER_TYPE),
+       }
+   )
+   String grid_type() default PROP_RESPONSIVE_TYPE;
 
     @AttributeDefinition(
         name = "Container ResourceType",


### PR DESCRIPTION
## Description

Due to how the rewriting a tree functions, when using the Responsive logic, the parent node order is not preserved. There becomes a conflict between the Column Control order being overwritten by the tree traversal.

Need to find a way to apply the Responsive handling for the Column Control rewriter, without losing the order.

## Changes

- Recursive call to find other column controls in the page and process them.
- Find the column start, break and end nodes and copy the content accordingly
- Add back the responsive column control conversation OSGI configurations prompt
- Preserve the order of the nodes in the tree after conversion. 

## Related Issue

[Support responsiveGrid
](https://github.com/adobe/aem-modernize-tools/issues/76)
## Motivation and Context

I noticed that the current column control conversion OSGI configuration doesn't support the responsiveGrid. I added it back to allow users to use it instead of creating new columns if they choose to. It also support having multiple column controls in the page and process them correctly now. previously it was only process one column control that exist in the page 

## How Has This Been Tested?

I test this locally by using the all-in-one conversion. 
- need to write unit-test

## Screenshots (if appropriate):

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
