### PR TITLE
FORMS-23537 dir browser will only show browser and empty folder will …

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/create/.content.xml
@@ -132,7 +132,7 @@
                                           multiple="{Boolean}false"
                                           name="sourceRoot"
                                           rootPath="/content/forms/af"
-                                          filter="hierarchyNotFile"
+                                          filter="folder"
                                           disabled="{Boolean}true">
                               </sourceRoot>
                               <targetRoot jcr:primaryType="nt:unstructured"
@@ -141,8 +141,8 @@
                                           required="{Boolean}false"
                                           multiple="{Boolean}false"
                                           name="targetRoot"
-                                          rootPath="/content/forms/af"
-                                          filter="hierarchyNotFile"
+                                          rootPath="/content/dam/formsanddocuments"
+                                          filter="folder"
                                           disabled="{Boolean}true"/>
                             </items>
                           </formConfig>


### PR DESCRIPTION
The Source Path and Target Path pickers in the Form Conversion job wizard had two issues:

- Source Path: filter was hierarchyNotFile, which shows all content nodes including non-folder items. Changed to folder to show only folders, consistent with how forms are organized under /content/forms/af.
- Target Path: rootPath was incorrectly set to /content/forms/af (same as source), and filter was hierarchyNotFile. The target for converted forms is the DAM path — changed rootPath to /content/dam/formsanddocuments and filter to folder.
 
Both pickers now browse the correct repository tree and surface only folder nodes.