### PR TITLE
fix: update job creation path defaults and remove Restore option

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/create/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/content/form/job/create/.content.xml
@@ -111,11 +111,6 @@
                                         value="NONE"
                                         text="None"
                                         checked="{Boolean}true"/>
-                                  <restore jcr:primaryType="nt:unstructured"
-                                           sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
-                                           value="RESTORE"
-                                           text="Restore"
-                                           fieldDescription="Select this to restore form to state before last Structure conversion."/>
                                   <copy jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/radiogroupitem"
                                         value="COPY"
@@ -132,7 +127,7 @@
                                           multiple="{Boolean}false"
                                           name="sourceRoot"
                                           rootPath="/content/forms/af"
-                                          filter="hierarchyNotFile"
+                                          filter="folder"
                                           disabled="{Boolean}true">
                               </sourceRoot>
                               <targetRoot jcr:primaryType="nt:unstructured"
@@ -141,8 +136,8 @@
                                           required="{Boolean}false"
                                           multiple="{Boolean}false"
                                           name="targetRoot"
-                                          rootPath="/content/forms/af"
-                                          filter="hierarchyNotFile"
+                                          rootPath="/content/dam/formsanddocuments"
+                                          filter="folder"
                                           disabled="{Boolean}true"/>
                             </items>
                           </formConfig>


### PR DESCRIPTION
sourceRoot/targetRoot filter: hierarchyNotFile → folder (restrict pickers to folders only). targetRoot rootPath: /content/forms/af → /content/dam/formsanddocuments (AF2 fragments land under DAM; align default with actual output location). Remove Restore radio option: unreliable for forms containing fragments since the pre-conversion version does not include converted fragment copies.