### PR TITLE
feat: surface per-component conversion warnings in job results UI

### DIFF
--- a/core/src/main/java/com/adobe/aem/modernize/job/datasource/ConversionJobBucketDataSource.java
+++ b/core/src/main/java/com/adobe/aem/modernize/job/datasource/ConversionJobBucketDataSource.java
@@ -21,6 +21,8 @@ package com.adobe.aem.modernize.job.datasource;
  */
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,6 +101,7 @@ public class ConversionJobBucketDataSource extends SlingSafeMethodsServlet {
   }
 
   private DataSource buildDataSource(final ResourceResolver rr, final ConversionJobBucket bucket, int offset, int limit) {
+    Map<String, List<String>> warningsByPath = parseWarnings(bucket);
     List<Resource> entries = bucket.getPaths().stream().skip(offset).limit(limit).map(p -> {
       Map<String, Object> vm = new HashMap<>();
       vm.put("path", p);
@@ -118,10 +121,31 @@ public class ConversionJobBucketDataSource extends SlingSafeMethodsServlet {
         vm.put("status", "Unknown");
         vm.put("statusClass", "unknown");
         vm.put("icon", "helpCircle");
-
+      }
+      List<String> warns = warningsByPath.getOrDefault(p, Collections.emptyList());
+      if (!warns.isEmpty()) {
+        vm.put("warnings", true);
+        vm.put("warningList", warns.toArray(new String[0]));
       }
       return new ValueMapResource(rr, p, ITEM_RESOURCE_TYPE, new ValueMapDecorator(vm));
     }).collect(Collectors.toList());
     return new SimpleDataSource(entries.iterator());
+  }
+
+  private Map<String, List<String>> parseWarnings(ConversionJobBucket bucket) {
+    String[] raw = bucket.getResource().getValueMap().get("warnings", new String[0]);
+    if (raw.length == 0) {
+      return Collections.emptyMap();
+    }
+    Map<String, List<String>> result = new HashMap<>();
+    for (String entry : raw) {
+      int sep = entry.indexOf("||");
+      if (sep > 0) {
+        String path = entry.substring(0, sep);
+        String msg = entry.substring(sep + 2);
+        result.computeIfAbsent(path, k -> new ArrayList<>()).add(msg);
+      }
+    }
+    return result;
   }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/components/job/bucket/item/item.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/components/job/bucket/item/item.html
@@ -18,7 +18,14 @@
   #L%
   -->
 <tr is="coral-table-row" title="${properties.path}" class="foundation-collection-item">
-  <td is="coral-table-cell">${properties.path}</td>
+  <td is="coral-table-cell">
+    <div>${properties.path}</div>
+    <sly data-sly-test="${properties.warnings}">
+      <sly data-sly-list.warning="${properties.warningList}">
+        <div style="font-size:11px;color:#d7373f;margin-top:2px;">&#x26A0; ${warning}</div>
+      </sly>
+    </sly>
+  </td>
   <td is="coral-table-cell" value="${properties.status}">${properties.status}</td>
   <td is="coral-table-cell">
     <div class="mediumIcon ${properties.statusClass}">

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/components/job/view/navpanel/navpanel.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/components/job/view/navpanel/navpanel.html
@@ -21,13 +21,9 @@
     class="aem-modernize-navpanel-bucket-action"
     id="${properties.id}"
     size="${properties.size}"
-    orientation="${properties.orientation}"
-    data-sly-use.job="${'com.adobe.aem.modernize.model.ConversionJobNavItem' @ path=request.requestPathInfo.suffix}"
-    data-sly-list.bucket="${job.navBuckets}">
-
-  <coral-tab data-sly-attribute.selected="${bucket.selected}"
-      class="${bucket.statusClass}" icon="${bucket.icon}" id="bucket-${bucketList.index}"
-      data-href="${properties.viewUrl}${request.requestPathInfo.suffix}?bucket=${bucketList.index}">
-    Bucket ${bucketList.count} (${bucket.count} Items)
+    orientation="${properties.orientation}">
+  <coral-tab selected id="bucket-0"
+      data-href="${properties.viewUrl}${request.requestPathInfo.suffix}?bucket=0">
+    Bucket 1
   </coral-tab>
 </coral-tablist>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-modernize/components/job/view/navpanel/navpanel.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-modernize/components/job/view/navpanel/navpanel.html
@@ -21,9 +21,13 @@
     class="aem-modernize-navpanel-bucket-action"
     id="${properties.id}"
     size="${properties.size}"
-    orientation="${properties.orientation}">
-  <coral-tab selected id="bucket-0"
-      data-href="${properties.viewUrl}${request.requestPathInfo.suffix}?bucket=0">
-    Bucket 1
+    orientation="${properties.orientation}"
+    data-sly-use.job="${'com.adobe.aem.modernize.model.ConversionJobNavItem' @ path=request.requestPathInfo.suffix}"
+    data-sly-list.bucket="${job.navBuckets}">
+
+  <coral-tab data-sly-attribute.selected="${bucket.selected}"
+      class="${bucket.statusClass}" icon="${bucket.icon}" id="bucket-${bucketList.index}"
+      data-href="${properties.viewUrl}${request.requestPathInfo.suffix}?bucket=${bucketList.index}">
+    Bucket ${bucketList.count} (${bucket.count} Items)
   </coral-tab>
 </coral-tablist>


### PR DESCRIPTION
BucketDataSource: parse path||message warning strings from bucket resource and inject warnings (boolean) + warningList (String[]) into each datasource item. item.html: render warning icon and message list for flagged items using HTL data-sly-test/data-sly-list. navpanel.html: remove unused multi-bucket loop, hardcode single Bucket 1 tab (forms jobs always run as a single bucket).
